### PR TITLE
Remove date time picker until library has versioning implemented in sync with Angular versioning.

### DIFF
--- a/projects/entry-form/src/public-api.ts
+++ b/projects/entry-form/src/public-api.ts
@@ -7,7 +7,9 @@ export * from './lib/services';
 export { FormlyAutocompleteModule } from './lib/components/autocomplete/formly-autocomplete.module';
 export { FormlyCkeditorModule } from './lib/components/ckeditor/formly-ckeditor.module';
 export { EntryCkeditorOptions, ENTRY_CKEDITOR_OPTIONS } from './lib/components/ckeditor/ckeditor-options';
-export { FormlyDateTimePickerModule } from './lib/components/date-time-picker/formly-date-time-picker.module';
-export { NgxMatDateFnsAdapter } from './lib/components/date-time-picker/date-fns-adapter';
+
+// Removed temporary until library has versioning implemented in sync with Angular versioning
+// export { FormlyDateTimePickerModule } from './lib/components/date-time-picker/formly-date-time-picker.module';
+// export { NgxMatDateFnsAdapter } from './lib/components/date-time-picker/date-fns-adapter';
 
 export { EntryFormModule } from './lib/entry-form.module';


### PR DESCRIPTION
Removed from public api (not included in build)