### PR TITLE
BP-537: Register Autocomplete in EntryFormModule.

### DIFF
--- a/projects/entry-form/entry-form.module.ts
+++ b/projects/entry-form/entry-form.module.ts
@@ -1,10 +1,12 @@
 import { NgModule } from '@angular/core';
 import { ENTRY_FIELD_TYPE_RESOLVER, fieldTypeResolverFactory, FieldTypeResolverService } from './services';
+import { FormlyAutocompleteModule } from './autocomplete/formly-autocomplete.module';
 
 @NgModule({
   declarations: [
   ],
   imports: [
+    FormlyAutocompleteModule
   ],
   providers: [
     {


### PR DESCRIPTION
Fix breaking change introduces by splitting form components in individual bundles.
Autocomplete module doesn't have to be imported separately.