### PR TITLE
BP-644: entry-cell-formatted-value: don't use custom defaults in currency and date pipes

### DIFF
--- a/libs/entry-table/src/lib/components/entry-cell-formatted-value/entry-cell-formatted-value.component.html
+++ b/libs/entry-table/src/lib/components/entry-cell-formatted-value/entry-cell-formatted-value.component.html
@@ -9,8 +9,7 @@
   </ng-container>
   <!-- Currency -->
   <ng-container *ngSwitchCase="'currency'">
-    {{value | currency: typeParameter?.currencyCode ?? defaultCurrencyCode :
-      typeParameter?.display : typeParameter?.digitsInfo : typeParameter?.locale}}
+    {{value | currency: typeParameter?.currencyCode : typeParameter?.display : typeParameter?.digitsInfo : typeParameter?.locale}}
   </ng-container>
   <!-- Percent -->
   <ng-container *ngSwitchCase="'percent'">
@@ -18,9 +17,7 @@
   </ng-container>
   <!-- Date -->
   <ng-container *ngSwitchCase="'date'">
-    {{value | date: typeParameter?.format ?? defaultDateFormat
-      : typeParameter?.timezone ?? defaultTimezone
-      : typeParameter?.locale}}
+    {{value | date: typeParameter?.format : typeParameter?.timezone : typeParameter?.locale}}
   </ng-container>
   <!-- Link -->
   <ng-container *ngSwitchCase="'link'">

--- a/libs/entry-table/src/lib/components/entry-cell-formatted-value/entry-cell-formatted-value.component.ts
+++ b/libs/entry-table/src/lib/components/entry-cell-formatted-value/entry-cell-formatted-value.component.ts
@@ -1,5 +1,5 @@
-import { ChangeDetectionStrategy, Component, DEFAULT_CURRENCY_CODE, Inject, Input } from '@angular/core';
-import { DEFAULT_DATE_FORMAT, DEFAULT_PERCENTAGE_MULTIPLIER, DEFAULT_TIMEZONE } from '../../interfaces/entry-table-config';
+import { ChangeDetectionStrategy, Component, Inject, Input } from '@angular/core';
+import { DEFAULT_PERCENTAGE_MULTIPLIER } from '../../interfaces/entry-table-config';
 
 @Component({
   selector: 'entry-cell-formatted-value',
@@ -13,9 +13,6 @@ export class EntryCellFormattedValueComponent {
   @Input() typeParameter: any | undefined;
 
   constructor(
-    @Inject(DEFAULT_DATE_FORMAT) public defaultDateFormat: string,
-    @Inject(DEFAULT_TIMEZONE) public defaultTimezone: string,
-    @Inject(DEFAULT_CURRENCY_CODE) public defaultCurrencyCode: string,
     @Inject(DEFAULT_PERCENTAGE_MULTIPLIER) public defaultPercentageMultiplier: number) {
   }
 }

--- a/libs/entry-table/src/lib/entry-table.module.ts
+++ b/libs/entry-table/src/lib/entry-table.module.ts
@@ -13,7 +13,7 @@ import { EntryTableComponent } from './components/entry-table/entry-table.compon
 import { EntryCellComponent } from './components/entry-cell/entry-cell.component';
 import { EntryCellContextMenuComponent } from './components/entry-cell-context-menu/entry-cell-context-menu.component';
 import { EntryCellFormattedValueComponent } from './components/entry-cell-formatted-value/entry-cell-formatted-value.component';
-import { DEFAULT_DATE_FORMAT, DEFAULT_TIMEZONE, DEFAULT_PERCENTAGE_MULTIPLIER } from './interfaces';
+import { DEFAULT_PERCENTAGE_MULTIPLIER } from './interfaces';
 
 @NgModule({
   imports: [
@@ -41,8 +41,6 @@ import { DEFAULT_DATE_FORMAT, DEFAULT_TIMEZONE, DEFAULT_PERCENTAGE_MULTIPLIER } 
     EntryCellFormattedValueComponent
   ],
   providers: [
-    { provide: DEFAULT_DATE_FORMAT, useValue: 'mediumDate' },
-    { provide: DEFAULT_TIMEZONE, useValue: 'undefined' },
     { provide: DEFAULT_PERCENTAGE_MULTIPLIER, useValue: 1 }
   ]
 })

--- a/libs/entry-table/src/lib/interfaces/entry-table-config.ts
+++ b/libs/entry-table/src/lib/interfaces/entry-table-config.ts
@@ -17,6 +17,4 @@ export const ENTRY_TABLE_CONFIG = new InjectionToken<EntryTableConfig>(
   });
 
 
-export const DEFAULT_DATE_FORMAT: InjectionToken<string> = new InjectionToken<string>('');
-export const DEFAULT_TIMEZONE: InjectionToken<string> = new InjectionToken<string>('');
 export const DEFAULT_PERCENTAGE_MULTIPLIER: InjectionToken<number> = new InjectionToken<number>('');


### PR DESCRIPTION
Remove DEFAULT_DATE_FORMAT and DEFAULT_TIMEZONE injection tokens from entry-table module. From Angular 15 the date pipe uses the DATE_PIPE_DEFAULT_OPTIONS injection token for default dateFormat and timezone values.