### PR TITLE
Less verbose way of providing configuration for entry components. Add entry-components.module.ts to simplify importing entry components in projects.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,7 +37,8 @@
             "style": "camelCase"
           }
         ],
-        "no-underscore-dangle": "off"
+        "no-underscore-dangle": "off",
+        "prefer-arrow/prefer-arrow-functions": "off"
       }
     },
     {

--- a/apps/demo-app/src/app/examples/button/button-example.module.ts
+++ b/apps/demo-app/src/app/examples/button/button-example.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ButtonExampleComponent } from './button-example/button-example.component';
 import { SharedModule } from '../../shared/shared.module';
-import { ENTRY_BUTTON_CONFIG, EntryButtonConfig, EntryButtonModule } from '@enigmatry/entry-components/button';
+import { EntryButtonModule, provideEntryButtonConfig } from '@enigmatry/entry-components/button';
 
 @NgModule({
   declarations: [
@@ -16,12 +16,12 @@ import { ENTRY_BUTTON_CONFIG, EntryButtonConfig, EntryButtonModule } from '@enig
   exports: [
     ButtonExampleComponent
   ],
-  providers: [{
-    provide: ENTRY_BUTTON_CONFIG,
-    useValue: new EntryButtonConfig({
+  providers: [
+    provideEntryButtonConfig({
       submit: { type: 'raised', color: 'primary' },
       cancel: { type: 'basic', color: 'accent' }
     })
-  }]
+  ]
 })
 export class ButtonExampleModule { }
+

--- a/apps/demo-app/src/app/examples/search-filter/search-filter-examples.module.ts
+++ b/apps/demo-app/src/app/examples/search-filter/search-filter-examples.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SearchFilterExampleComponent } from './search-filter/search-filter-example.component';
 import { SharedModule } from '../../shared/shared.module';
-import { ENTRY_SEARCH_FILTER_CONFIG, EntrySearchFilterConfig, EntrySearchFilterModule } from '@enigmatry/entry-components/search-filter';
+import { EntrySearchFilterModule, provideEntrySearchFilterConfig } from '@enigmatry/entry-components/search-filter';
 import { MatTableModule } from '@angular/material/table';
 import { EnumToStringPipe } from './search-filter/enum-to-string.pipe';
 
@@ -21,12 +21,9 @@ import { EnumToStringPipe } from './search-filter/enum-to-string.pipe';
     SearchFilterExampleComponent
   ],
   providers: [
-    {
-      provide: ENTRY_SEARCH_FILTER_CONFIG,
-      useFactory: () => new EntrySearchFilterConfig({
-        applyButtonText: 'Filter'
-      })
-    }
+    provideEntrySearchFilterConfig({
+      applyButtonText: 'Filter'
+    })
   ]
 })
 export class SearchFilterExamplesModule { }

--- a/apps/demo-app/src/app/examples/validation/reactive-form/reactive-form-validation-example.module.ts
+++ b/apps/demo-app/src/app/examples/validation/reactive-form/reactive-form-validation-example.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormExampleComponent } from './reactive-form-validation-example.component';
 import { AbstractControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { ENTRY_VALIDATION_CONFIG, EntryValidationConfig, EntryValidationModule } from '@enigmatry/entry-components/validation';
+import { EntryValidationModule, provideEntryValidationConfig } from '@enigmatry/entry-components/validation';
 import { SharedModule } from '../../../shared/shared.module';
 
 @NgModule({
@@ -20,16 +20,12 @@ import { SharedModule } from '../../../shared/shared.module';
     ReactiveFormExampleComponent
   ],
   providers: [
-    {
-      provide: ENTRY_VALIDATION_CONFIG,
-      useFactory: () => new EntryValidationConfig({
-        /** Configure validation messages for standard client side validators */
-        validationMessages: [
-          { name: 'required', message: 'This field is mandatory!' },
-          { name: 'minlength', message: (control: AbstractControl) => `Minimal length is ${control.errors.minlength.requiredLength}!`}
-        ]
-      })
-    }
+    provideEntryValidationConfig({
+      validationMessages: [
+        { name: 'required', message: 'This field is mandatory!' },
+        { name: 'minlength', message: (control: AbstractControl) => `Minimal length is ${control.errors.minlength.requiredLength}!` }
+      ]
+    })
   ]
 })
 export class ReactiveFormValidationExampleModule { }

--- a/apps/demo-app/src/app/shared/shared.module.ts
+++ b/apps/demo-app/src/app/shared/shared.module.ts
@@ -1,4 +1,4 @@
-import { NgModule  } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MaterialModule } from './material/material.module';
 import { DocumentationContentComponent } from './documentation-content/documentation-content.component';
@@ -7,7 +7,7 @@ import { ExampleViewerComponent } from './example-viewer/example-viewer.componen
 import { MarkdownViewerComponent } from './markdown-viewer/markdown-viewer.component';
 import { SortPipe } from './pipes/sort.pipe';
 import { CodeViewComponent } from './example-viewer/code-view/code-view.component';
-import { ENTRY_BUTTON_CONFIG, EntryButtonConfig, EntryButtonModule } from '@enigmatry/entry-components/button';
+import { EntryButtonModule, provideEntryButtonConfig } from '@enigmatry/entry-components/button';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 @NgModule({
@@ -34,12 +34,11 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
     MarkdownViewerComponent,
     SortPipe
   ],
-  providers: [{
-    provide: ENTRY_BUTTON_CONFIG,
-    useValue: new EntryButtonConfig({
+  providers: [
+    provideEntryButtonConfig({
       submit: { type: 'raised', color: 'primary' },
-      cancel: { type: 'basic', }
+      cancel: { type: 'basic' }
     })
-  }]
+  ]
 })
 export class SharedModule { }

--- a/libs/entry-components/button/README.md
+++ b/libs/entry-components/button/README.md
@@ -22,19 +22,18 @@ import { EntryButtonModule } from '@enigmatry/entry-components/button';
 Provide configuration for submit or cancel button in feature or shared module.
 
 ```typescript
-import { ENTRY_BUTTON_CONFIG, EntryButtonConfig, EntryButtonModule } from '@enigmatry/entry-components/button';
+import { EntryButtonModule, provideEntryButtonConfig } from '@enigmatry/entry-components/button';
 
 @NgModule({
   declarations: [],
   imports: [],
   exports: [],
-  providers: [{
-    provide: ENTRY_BUTTON_CONFIG,
-    useValue: new EntryButtonConfig({
+  providers: [
+    provideEntryButtonConfig({
       submit: { type: 'raised', color: 'primary' },
-      cancel: { type: 'basic', }
+      cancel: { type: 'basic' }
     })
-  }]
+  ]
 })
 export class SharedModule { }
 ```

--- a/libs/entry-components/button/entry-button-config.ts
+++ b/libs/entry-components/button/entry-button-config.ts
@@ -1,5 +1,6 @@
-import { InjectionToken } from '@angular/core';
+import { Provider } from '@angular/core';
 import { ThemePalette } from '@angular/material/core';
+import { createInjectionToken, provideConfig } from '@enigmatry/entry-components/common';
 
 /** Possible mat button variants */
 export declare type MatButtonVariants = 'basic' | 'flat' | 'raised' | 'stroked';
@@ -26,15 +27,17 @@ export class EntryButtonConfig {
 }
 
 /**
- * Entry button config injection token. Can be used to provide custom button configuration.
+ * Entry button config injection token.
  *
  * Defaults:
  * - submit: type: 'flat', color: 'primary'
  * - cancel: type: 'basic', color: 'accent'
  */
-export const ENTRY_BUTTON_CONFIG = new InjectionToken<EntryButtonConfig>('EntryButtonConfig',
-  {
-    providedIn: 'root',
-    factory: () => new EntryButtonConfig()
-  }
-);
+export const ENTRY_BUTTON_CONFIG = createInjectionToken(new EntryButtonConfig());
+
+/**
+ * Can be used to provide custom button configuration.
+ */
+export function provideEntryButtonConfig(config: Partial<EntryButtonConfig>): Provider {
+  return provideConfig(ENTRY_BUTTON_CONFIG, () => new EntryButtonConfig(config));
+}

--- a/libs/entry-components/button/public-api.ts
+++ b/libs/entry-components/button/public-api.ts
@@ -1,4 +1,4 @@
 export { EntryButtonDirective } from './entry-button.directive';
 export { EntryButtonModule } from './entry-button.module';
 
-export { ENTRY_BUTTON_CONFIG, EntryButtonConfig } from './entry-button-config';
+export { ENTRY_BUTTON_CONFIG, EntryButtonConfig, provideEntryButtonConfig } from './entry-button-config';

--- a/libs/entry-components/common/ng-package.json
+++ b/libs/entry-components/common/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "./public-api.ts"
+  }
+}

--- a/libs/entry-components/common/public-api.ts
+++ b/libs/entry-components/common/public-api.ts
@@ -1,0 +1,1 @@
+export * from './utils';

--- a/libs/entry-components/common/utils/index.ts
+++ b/libs/entry-components/common/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './provide-config';

--- a/libs/entry-components/common/utils/provide-config.ts
+++ b/libs/entry-components/common/utils/provide-config.ts
@@ -1,0 +1,17 @@
+import { InjectionToken, Provider } from '@angular/core';
+
+export function createInjectionToken<T>(defaultValue: T): InjectionToken<T> {
+  return new InjectionToken<T>(defaultValue.constructor.name,
+    {
+      providedIn: 'root',
+      factory: () => defaultValue
+    }
+  );
+}
+
+export function provideConfig<T>(token: InjectionToken<T>, factory: () => T): Provider {
+  return {
+    provide: token,
+    useFactory: factory
+  };
+}

--- a/libs/entry-components/dialog/README.md
+++ b/libs/entry-components/dialog/README.md
@@ -53,21 +53,20 @@ Default values are:
 To override with custom defaults use providers on application level:
 
 ```ts
+import { EntryDialogModule, provideEntryDialogConfig } from '@enigmatry/entry-components/dialog';
+
 @NgModule({
   imports: [
     EntryDialogModule
   ],
   providers: [
-    {
-        provide: ENTRY_DIALOG_CONFIG,
-        useFactory: () => new EntryDialogConfig({
-          confirmButtonText: 'Yes',
-          cancelButtonText: 'No',
-          buttonsAlignment: 'end',
-          hideClose: false,
-          disableClose: true
-        })
-    }
+    provideEntryDialogConfig({
+      confirmButtonText: 'Yes',
+      cancelButtonText: 'No',
+      buttonsAlignment: 'end',
+      hideClose: false,
+      disableClose: true
+    })
   ]
 })
 export class AppModule { }

--- a/libs/entry-components/dialog/entry-dialog-config.model.ts
+++ b/libs/entry-components/dialog/entry-dialog-config.model.ts
@@ -1,5 +1,6 @@
-import { InjectionToken } from '@angular/core';
+import { createInjectionToken, provideConfig } from '@enigmatry/entry-components/common';
 import { EntryDialogButtonsAlignment } from './entry-dialog-buttons-alignment.type';
+import { Provider } from '@angular/core';
 
 /**
  * Used to provide default configurations on module level.
@@ -27,7 +28,6 @@ export class EntryDialogConfig {
 
 /**
  * Entry dialog injection token of EntryDialogConfig type containing dialog default configurations.
- * Can be updated with custom configuration.
  *
  * Defaults:
  * - confirmButtonText: 'Ok'
@@ -36,10 +36,11 @@ export class EntryDialogConfig {
  * - hideClose: true
  * - disableClose: false
  */
-export const ENTRY_DIALOG_CONFIG = new InjectionToken<EntryDialogConfig>(
-    'EntryDialogConfig',
-    {
-        providedIn: 'root',
-        factory: () => new EntryDialogConfig()
-    }
-);
+export const ENTRY_DIALOG_CONFIG = createInjectionToken(new EntryDialogConfig());
+
+/**
+ * Can be used to provide entry dialog configuration.
+ */
+export function provideEntryDialogConfig(config: Partial<EntryDialogConfig>): Provider {
+    return provideConfig(ENTRY_DIALOG_CONFIG, () => new EntryDialogConfig(config));
+}

--- a/libs/entry-components/dialog/public-api.ts
+++ b/libs/entry-components/dialog/public-api.ts
@@ -11,4 +11,4 @@ export { EntryDialogButtonsAlignment } from './entry-dialog-buttons-alignment.ty
 export { EntryDialogService } from './entry-dialog.service';
 export { EntryDialogModule } from './entry-dialog.module';
 
-export { ENTRY_DIALOG_CONFIG, EntryDialogConfig } from './entry-dialog-config.model';
+export { ENTRY_DIALOG_CONFIG, EntryDialogConfig, provideEntryDialogConfig } from './entry-dialog-config.model';

--- a/libs/entry-components/entry-components.module.ts
+++ b/libs/entry-components/entry-components.module.ts
@@ -1,0 +1,39 @@
+import { ModuleWithProviders, NgModule, Provider, Type } from '@angular/core';
+import { EntryButtonModule } from '@enigmatry/entry-components/button';
+import { EntryDialogModule } from '@enigmatry/entry-components/dialog';
+import { EntryPermissionModule, EntryPermissionService } from '@enigmatry/entry-components/permissions';
+import { EntrySearchFilterModule } from '@enigmatry/entry-components/search-filter';
+import { EntryValidationModule } from '@enigmatry/entry-components/validation';
+import { EntryFileInputModule } from '@enigmatry/entry-components/file-input';
+
+interface ModuleForRootOptions {
+  permissionService?: Type<any>;
+}
+
+@NgModule({
+  declarations: [],
+  exports: [
+    EntryButtonModule,
+    EntryDialogModule,
+    EntryFileInputModule,
+    EntryValidationModule,
+    EntryPermissionModule,
+    EntrySearchFilterModule
+  ],
+  providers: []
+})
+export class EntryComponentsModule {
+  static forRoot(options: ModuleForRootOptions = {}): ModuleWithProviders<EntryComponentsModule> {
+    const providers: Provider[] = options.permissionService
+      ? [{
+        provide: EntryPermissionService,
+        useClass: options.permissionService
+      }]
+      : [];
+
+    return {
+      ngModule: EntryComponentsModule,
+      providers
+    };
+  }
+}

--- a/libs/entry-components/modules/entry-components.module.ts
+++ b/libs/entry-components/modules/entry-components.module.ts
@@ -5,11 +5,19 @@ import { EntryPermissionModule, EntryPermissionService } from '@enigmatry/entry-
 import { EntrySearchFilterModule } from '@enigmatry/entry-components/search-filter';
 import { EntryValidationModule } from '@enigmatry/entry-components/validation';
 import { EntryFileInputModule } from '@enigmatry/entry-components/file-input';
+import { EntryTableModule } from '@enigmatry/entry-components/table';
 
-interface ModuleForRootOptions {
+interface ModuleRootProviderOptions {
   permissionService?: Type<any>;
 }
 
+/**
+ * Exports all entry components.
+ *
+ * Usage
+ * import EntryComponentsModule in shared.module.ts to have access to all components, directives, pipes.
+ * import EntryComponentsModule.forRoot() in app.module.ts to register root module providers.
+ */
 @NgModule({
   declarations: [],
   exports: [
@@ -18,12 +26,12 @@ interface ModuleForRootOptions {
     EntryFileInputModule,
     EntryValidationModule,
     EntryPermissionModule,
-    EntrySearchFilterModule
-  ],
-  providers: []
+    EntrySearchFilterModule,
+    EntryTableModule
+  ]
 })
 export class EntryComponentsModule {
-  static forRoot(options: ModuleForRootOptions = {}): ModuleWithProviders<EntryComponentsModule> {
+  static forRoot(options: ModuleRootProviderOptions = {}): ModuleWithProviders<EntryComponentsModule> {
     const providers: Provider[] = options.permissionService
       ? [{
         provide: EntryPermissionService,

--- a/libs/entry-components/modules/entry-components.module.ts
+++ b/libs/entry-components/modules/entry-components.module.ts
@@ -7,7 +7,7 @@ import { EntryValidationModule } from '@enigmatry/entry-components/validation';
 import { EntryFileInputModule } from '@enigmatry/entry-components/file-input';
 import { EntryTableModule } from '@enigmatry/entry-components/table';
 
-interface ModuleRootProviderOptions {
+interface EntryComponentsModuleOptions {
   permissionService?: Type<any>;
 }
 
@@ -31,14 +31,13 @@ interface ModuleRootProviderOptions {
   ]
 })
 export class EntryComponentsModule {
-  static forRoot(options: ModuleRootProviderOptions = {}): ModuleWithProviders<EntryComponentsModule> {
-    const providers: Provider[] = options.permissionService
-      ? [{
-        provide: EntryPermissionService,
-        useClass: options.permissionService
-      }]
+  static forRoot(options: EntryComponentsModuleOptions = {}): ModuleWithProviders<EntryComponentsModule> {
+
+    const permissionServiceProvider: Provider[] = options.permissionService
+      ? [{ provide: EntryPermissionService, useClass: options.permissionService }]
       : [];
 
+    const providers: Provider[] = [...permissionServiceProvider];
     return {
       ngModule: EntryComponentsModule,
       providers

--- a/libs/entry-components/public-api.ts
+++ b/libs/entry-components/public-api.ts
@@ -8,5 +8,6 @@ export * from '@enigmatry/entry-components/file-input';
 export * from '@enigmatry/entry-components/permissions';
 export * from '@enigmatry/entry-components/search-filter';
 export * from '@enigmatry/entry-components/validation';
+export * from '@enigmatry/entry-components/table';
 
-export { EntryComponentsModule } from './entry-components.module';
+export { EntryComponentsModule } from './modules/entry-components.module';

--- a/libs/entry-components/public-api.ts
+++ b/libs/entry-components/public-api.ts
@@ -1,10 +1,12 @@
+
 /*
  * Public API Surface of entry-components
  */
-
-export * from '@enigmatry/entry-components/dialog';
-export * from '@enigmatry/entry-components/search-filter';
-export * from '@enigmatry/entry-components/validation';
 export * from '@enigmatry/entry-components/button';
+export * from '@enigmatry/entry-components/dialog';
 export * from '@enigmatry/entry-components/file-input';
 export * from '@enigmatry/entry-components/permissions';
+export * from '@enigmatry/entry-components/search-filter';
+export * from '@enigmatry/entry-components/validation';
+
+export { EntryComponentsModule } from './entry-components.module';

--- a/libs/entry-components/search-filter/README.md
+++ b/libs/entry-components/search-filter/README.md
@@ -43,11 +43,7 @@ Where `APP_THEME` represents application theming configuration, while `APP_TYPOG
 `ENTRY_SEARCH_FILTER_CONFIG`: `InjectionToken<EntrySearchFilterConfig>` - Optional configuration used to override defaults.
 
 ```ts
-import {
-  EntrySearchFilterModule,
-  ENTRY_SEARCH_FILTER_CONFIG,
-  EntrySearchFilterConfig
-} from '@enigmatry/entry-components/search-filter';
+import { EntrySearchFilterModule, provideEntrySearchFilterConfig } from '@enigmatry/entry-components/search-filter';
 // ...
 
 @NgModule({
@@ -55,14 +51,10 @@ import {
     EntrySearchFilterModule
   ],
   providers: [
-    {
-      provide: ENTRY_SEARCH_FILTER_CONFIG,
-      useFactory: () => new EntrySearchFilterConfig({
-        applyButtonText: 'Filter',
-        noneSelectedOptionText: 'None'
-      })
-    }
+    provideEntrySearchFilterConfig({
+      applyButtonText: 'Filter'
+    })
   ]
 })
-export class AppModule { }
+export class SharedModule { }
 ```

--- a/libs/entry-components/search-filter/public-api.ts
+++ b/libs/entry-components/search-filter/public-api.ts
@@ -8,4 +8,4 @@ export { SelectFilterOption } from './search-filter-input/inputs/select-filter-o
 
 export { EntrySearchFilterModule } from './entry-search-filter.module';
 
-export { ENTRY_SEARCH_FILTER_CONFIG, EntrySearchFilterConfig } from './search-filter-config.model';
+export { ENTRY_SEARCH_FILTER_CONFIG, EntrySearchFilterConfig, provideEntrySearchFilterConfig } from './search-filter-config.model';

--- a/libs/entry-components/search-filter/search-filter-config.model.ts
+++ b/libs/entry-components/search-filter/search-filter-config.model.ts
@@ -1,7 +1,8 @@
-import { InjectionToken } from '@angular/core';
+import { Provider } from '@angular/core';
+import { createInjectionToken, provideConfig } from '@enigmatry/entry-components/common';
 
 /**
- * Used to provide default configurations on module level.
+ * Used to provide entry search filter configuration on module level.
  */
 export class EntrySearchFilterConfig {
     /** Apply search filters button label (default 'Apply') */
@@ -14,10 +15,11 @@ export class EntrySearchFilterConfig {
         this.noneSelectedOptionText = config.noneSelectedOptionText ?? 'None';
     }
 }
-export const ENTRY_SEARCH_FILTER_CONFIG = new InjectionToken<EntrySearchFilterConfig>(
-    'EntrySearchFilterConfig',
-    {
-        providedIn: 'root',
-        factory: () => new EntrySearchFilterConfig()
-    }
-);
+export const ENTRY_SEARCH_FILTER_CONFIG = createInjectionToken(new EntrySearchFilterConfig());
+
+/**
+ * Can be used to provide entry search filter configuration.
+ */
+export function provideEntrySearchFilterConfig(config: Partial<EntrySearchFilterConfig>): Provider {
+    return provideConfig(ENTRY_SEARCH_FILTER_CONFIG, () => new EntrySearchFilterConfig(config));
+}

--- a/libs/entry-components/validation/README.md
+++ b/libs/entry-components/validation/README.md
@@ -68,7 +68,7 @@ Optionally, when using Reactive form, client side validation messages can be con
 ```ts
 // ...
 import { AbstractControl } from '@angular/forms';
-import { ENTRY_VALIDATION_CONFIG, EntryValidationConfig, EntryValidationModule } from '@enigmatry/entry-components/validation';
+import { EntryValidationModule, provideEntryValidationConfig } from '@enigmatry/entry-components/validation';
 
 @NgModule({
   imports: [
@@ -76,15 +76,12 @@ import { ENTRY_VALIDATION_CONFIG, EntryValidationConfig, EntryValidationModule }
     EntryValidationModule
   ]
   providers: [
-    {
-      provide: ENTRY_VALIDATION_CONFIG,
-      useFactory: () => new EntryValidationConfig({
-        validationMessages: [
-          { name: 'required', message: 'This field is mandatory!' },
-          { name: 'minlength', message: (control: AbstractControl) => `Minimal length is ${control.errors.minlength.requiredLength}!`}
-        ]
-      })
-    }
+    provideEntryValidationConfig({
+      validationMessages: [
+        { name: 'required', message: 'This field is mandatory!' },
+        { name: 'minlength', message: (control: AbstractControl) => `Minimal length is ${control.errors.minlength.requiredLength}!` }
+      ]
+    })
   ]
 })
 export class AppModule { }

--- a/libs/entry-components/validation/entry-validation-config.model.ts
+++ b/libs/entry-components/validation/entry-validation-config.model.ts
@@ -1,5 +1,6 @@
-import { InjectionToken } from '@angular/core';
+import { Provider } from '@angular/core';
 import { AbstractControl } from '@angular/forms';
+import { createInjectionToken, provideConfig } from '@enigmatry/entry-components/common';
 
 /** Used to configure mapping between validation keys and messages */
 export interface IEntryValidationMessage {
@@ -47,10 +48,11 @@ export class EntryValidationConfig {
  * Defaults:
  * - validationMessages: []
  */
-export const ENTRY_VALIDATION_CONFIG = new InjectionToken<EntryValidationConfig>(
-    'EntryValidationConfig',
-    {
-        providedIn: 'root',
-        factory: () => new EntryValidationConfig()
-    }
-);
+export const ENTRY_VALIDATION_CONFIG = createInjectionToken(new EntryValidationConfig());
+
+/**
+ * Can be used to provide entry validation configuration.
+ */
+export function provideEntryValidationConfig(config: Partial<EntryValidationConfig>): Provider {
+    return provideConfig(ENTRY_VALIDATION_CONFIG, () => new EntryValidationConfig(config));
+}

--- a/libs/entry-components/validation/public-api.ts
+++ b/libs/entry-components/validation/public-api.ts
@@ -6,4 +6,4 @@ export { EntryValidationModule } from './entry-validation.module';
 export { IValidationProblemDetails } from './validation-problem-details.interface';
 export * from './entry-validation';
 
-export { ENTRY_VALIDATION_CONFIG, EntryValidationConfig, IEntryValidationMessage } from './entry-validation-config.model';
+export * from './entry-validation-config.model';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "paths": {
       "@enigmatry/entry-components":["libs/entry-components/public-api.ts"],
+      "@enigmatry/entry-components/common": ["libs/entry-components/common/public-api.ts"],
       "@enigmatry/entry-components/dialog":["libs/entry-components/dialog/public-api.ts"],
       "@enigmatry/entry-components/search-filter":["libs/entry-components/search-filter/public-api.ts"],
       "@enigmatry/entry-components/validation":["libs/entry-components/validation/public-api.ts"],


### PR DESCRIPTION
* Less verbose way of providing configuration for entry components. Add provideEntryXxxConfig method to reduce boilerplate imports.
* Add entry-components.module.ts that exports all entry components and can be used to simplify importing entry components in projects.