### PR TITLE
Align default page size with code gen default. Page size set to 20.

### DIFF
--- a/libs/entry-components/table/interfaces/paged-query.ts
+++ b/libs/entry-components/table/interfaces/paged-query.ts
@@ -1,7 +1,7 @@
 import { Params } from '@angular/router';
 import { OnPage, OnSort, PageEvent, SortDirection, SortEvent } from './pagination';
 
-export const defaultPageSize = 10;
+export const defaultPageSize = 20;
 export const defaultPageNumber = 1;
 
 export class PagedQuery implements OnPage, OnSort {


### PR DESCRIPTION
See:
https://github.com/enigmatry/entry-code-generation/pull/44