### PR TITLE
BP-508: Scroll to invalid form control when form is submitted.

### DIFF
--- a/apps/demo-app/src/app/examples/form/form-example/form-example.component.html
+++ b/apps/demo-app/src/app/examples/form/form-example/form-example.component.html
@@ -1,7 +1,7 @@
-<app-g-product-edit [formButtonsTemplate]="buttons"></app-g-product-edit>
+<app-g-product-edit [formButtonsTemplate]="buttons" [fieldsRequiredExpressions]="requiredFields"></app-g-product-edit>
 <ng-template #buttons>
   <div class="action-buttons">
     <button mat-button entry-submit-button type="submit">Submit</button>
-    <button mat-button entry-cancel-button>Cancel</button>
+    <button mat-button entry-cancel-button type="button">Cancel</button>
   </div>
 </ng-template>

--- a/apps/demo-app/src/app/examples/form/form-example/form-example.component.md
+++ b/apps/demo-app/src/app/examples/form/form-example/form-example.component.md
@@ -34,7 +34,7 @@ public class ProductEditComponentConfiguration : IFormComponentConfiguration<Get
             .WithPlaceholder("Units")
             .WithPlaceholderTranslationId(ProductTranslationId.Amount);
 
-        builder.DateTimePickerFormControl(x => x.ExpiresOn);
+        builder.DatepickerFormControl(x => x.ExpiresOn);
 
         builder.CheckboxFormControl(x => x.FreeShipping)
             .WithDefaultValue(true);

--- a/apps/demo-app/src/app/examples/form/form-example/form-example.component.ts
+++ b/apps/demo-app/src/app/examples/form/form-example/form-example.component.ts
@@ -6,4 +6,8 @@ import { Component } from '@angular/core';
   styleUrls: ['./form-example.component.scss']
 })
 export class FormExampleComponent {
+  requiredFields = {
+    name: () => true,
+    type: () => true
+  };
 }

--- a/apps/demo-app/src/app/examples/form/form-example/generated/product-edit/product-edit-generated.component.ts
+++ b/apps/demo-app/src/app/examples/form/form-example/generated/product-edit/product-edit-generated.component.ts
@@ -175,9 +175,9 @@ className: `entry-amount-field entry-input`,
         },
         {
         key: 'expiresOn',
-        type: this.resolveFieldType('datetimepicker', false),
+        type: this.resolveFieldType('datepicker', false),
         focus: false,
-className: `entry-expires-on-field entry-datetimepicker`,
+className: `entry-expires-on-field entry-datepicker`,
         hideExpression: this.fieldsHideExpressions?.expiresOn ?? false,
         expressionProperties: {
         'templateOptions.disabled': (model) => (this.isReadonly || (this.fieldsDisableExpressions?.expiresOn ? this.fieldsDisableExpressions.expiresOn(model) : false)),

--- a/apps/demo-app/src/app/shared/shared.module.ts
+++ b/apps/demo-app/src/app/shared/shared.module.ts
@@ -9,6 +9,7 @@ import { SortPipe } from './pipes/sort.pipe';
 import { CodeViewComponent } from './example-viewer/code-view/code-view.component';
 import { EntryButtonModule, provideEntryButtonConfig } from '@enigmatry/entry-components/button';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { EntryCommonModule } from '@enigmatry/entry-components/common';
 
 @NgModule({
   declarations: [
@@ -26,9 +27,10 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
   ],
   exports: [
     MaterialModule,
-    EntryButtonModule,
     FormsModule,
     ReactiveFormsModule,
+    EntryButtonModule,
+    EntryCommonModule,
     DocumentationContentComponent,
     ExampleViewerComponent,
     MarkdownViewerComponent,

--- a/libs/entry-components/.eslintrc.json
+++ b/libs/entry-components/.eslintrc.json
@@ -20,7 +20,7 @@
           "error",
           {
             "type": "attribute",
-            "prefix": "entry",
+            "prefix": ["entry", ""],
             "style": "camelCase"
           }
         ],

--- a/libs/entry-components/common/README.md
+++ b/libs/entry-components/common/README.md
@@ -1,0 +1,19 @@
+# Entry common
+
+EntryCommonModule includes a set of commonly used directives, pipes, services and utilities.
+
+`import { EntryCommonModule } from '@enigmatry/entry-components/common';`
+
+## Directives
+
+### `ScrollToInvalidControlDirective`
+
+Scrolls to first invalid form control when form is submitted.
+
+Selector: `form[formGroup],form[ngForm]`
+
+Directive is applied to reactive or template driven forms, no additional selectors are required. Directive will listen to form submit event and scroll to first invalid form control when form is invalid. For this to work, submit button should be enabled so users always get feedback of what is wrong.
+  
+## Pipes
+
+## Services

--- a/libs/entry-components/common/common.module.ts
+++ b/libs/entry-components/common/common.module.ts
@@ -1,0 +1,24 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+/** Directives */
+
+import { ScrollToInvalidControlDirective } from './directives/scroll-to-invalid-control.directive';
+
+const DIRECTIVES = [
+  ScrollToInvalidControlDirective
+];
+
+@NgModule({
+  declarations: [
+  ],
+  imports: [
+    CommonModule,
+    ...DIRECTIVES
+  ],
+  exports: [
+    ...DIRECTIVES
+  ]
+})
+export class EntryCommonModule {
+}

--- a/libs/entry-components/common/constants.ts
+++ b/libs/entry-components/common/constants.ts
@@ -1,0 +1,2 @@
+export const NG_VALID_CLASS = '.ng-valid';
+export const NG_INVALID_CLASS = '.ng-invalid';

--- a/libs/entry-components/common/directives/index.ts
+++ b/libs/entry-components/common/directives/index.ts
@@ -1,0 +1,1 @@
+export * from './scroll-to-invalid-control.directive';

--- a/libs/entry-components/common/directives/scroll-to-invalid-control.directive.ts
+++ b/libs/entry-components/common/directives/scroll-to-invalid-control.directive.ts
@@ -1,0 +1,49 @@
+import { Directive, ElementRef, OnDestroy, OnInit, Self } from '@angular/core';
+import { ControlContainer } from '@angular/forms';
+import { Subject, fromEvent } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { NG_INVALID_CLASS } from '../constants';
+
+/**
+ * Scroll to first invalid control when form is submitted.
+ * Directive is applied to 'form[formGroup],form[ngForm]' (reactive or template driven forms)
+ */
+@Directive({
+  standalone: true,
+  selector: 'form[formGroup],form[ngForm]'
+})
+export class ScrollToInvalidControlDirective implements OnInit, OnDestroy {
+
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    @Self() private form: ControlContainer,
+    private elementRef: ElementRef<HTMLFormElement>) { }
+
+  ngOnInit(): void {
+    fromEvent(this.elementRef.nativeElement, 'submit')
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(_ => {
+        if (this.form.invalid) {
+          this.scrollToInvalidControl();
+        }
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private scrollToInvalidControl() {
+    const firstInvalidControl: HTMLElement =
+      this.elementRef.nativeElement.querySelector(NG_INVALID_CLASS);
+
+    if (firstInvalidControl) {
+      firstInvalidControl.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center'  // vertical alignment
+      });
+    }
+  }
+}

--- a/libs/entry-components/common/public-api.ts
+++ b/libs/entry-components/common/public-api.ts
@@ -1,1 +1,4 @@
+export { EntryCommonModule } from './common.module';
+
 export * from './utils';
+export * from './directives';


### PR DESCRIPTION
* Add `ScrollToInvalidControlDirective`
* Directive is applied to reactive or template driven forms, no additional selectors are required.
* Directive will listen to form submit event and scroll to first invalid form control when invalid form is submitted.
* For directive to work, submit button should be enabled.