### PR TITLE
BP-952: Set font size for table header cells

### DIFF
--- a/libs/entry-components/styles/modules/_default-theme.scss
+++ b/libs/entry-components/styles/modules/_default-theme.scss
@@ -51,8 +51,7 @@ $theme: (
 	),
 	tables: (
 		header: (
-			font-size: null,
-			font-weight: null
+			font-size: null
 		),
 		cells: (
 			edge-gap: 4px,

--- a/libs/entry-components/styles/modules/_default-theme.scss
+++ b/libs/entry-components/styles/modules/_default-theme.scss
@@ -52,7 +52,11 @@ $theme: (
 	tables: (
 		cells: (
 			edge-gap: 4px,
-			padding: null
+			padding: null,
+			header: (
+				font-size: null,
+				font-weight: null
+			)
 		),
 		rows: (
 			selected-color: #FFF,

--- a/libs/entry-components/styles/modules/_default-theme.scss
+++ b/libs/entry-components/styles/modules/_default-theme.scss
@@ -50,13 +50,13 @@ $theme: (
 		)
 	),
 	tables: (
+		header: (
+			font-size: null,
+			font-weight: null
+		),
 		cells: (
 			edge-gap: 4px,
-			padding: null,
-			header: (
-				font-size: null,
-				font-weight: null
-			)
+			padding: null
 		),
 		rows: (
 			selected-color: #FFF,

--- a/libs/entry-components/styles/modules/components/tables/_header.scss
+++ b/libs/entry-components/styles/modules/components/tables/_header.scss
@@ -2,12 +2,8 @@
 
 @mixin generate-from($theme) {
 	$header-cell-font-size: map.get($theme, 'tables', 'header', 'font-size');
-	$header-cell-font-weight: map.get($theme, 'tables', 'header', 'font-weight');
 
 	.mat-mdc-header-cell {
-		font: {
-			size: $header-cell-font-size;
-			weight: $header-cell-font-weight;
-		}
+		font-size: $header-cell-font-size;
 	}
 }

--- a/libs/entry-components/styles/modules/components/tables/_header.scss
+++ b/libs/entry-components/styles/modules/components/tables/_header.scss
@@ -1,9 +1,9 @@
 @use 'sass:map';
 
 @mixin generate-from($theme) {
-	$header-cell-font-size: map.get($theme, 'tables', 'header', 'font-size');
+	$cell-font-size: map.get($theme, 'tables', 'header', 'font-size');
 
 	.mat-mdc-header-cell {
-		font-size: $header-cell-font-size;
+		font-size: $cell-font-size;
 	}
 }

--- a/libs/entry-components/styles/modules/components/tables/_header.scss
+++ b/libs/entry-components/styles/modules/components/tables/_header.scss
@@ -1,8 +1,8 @@
 @use 'sass:map';
 
 @mixin generate-from($theme) {
-	$header-cell-font-size: map.get($theme, 'tables', 'cells', 'header', 'font-size');
-	$header-cell-font-weight: map.get($theme, 'tables', 'cells', 'header', 'font-weight');
+	$header-cell-font-size: map.get($theme, 'tables', 'header', 'font-size');
+	$header-cell-font-weight: map.get($theme, 'tables', 'header', 'font-weight');
 
 	.mat-mdc-header-cell {
 		font: {

--- a/libs/entry-components/styles/modules/components/tables/_header.scss
+++ b/libs/entry-components/styles/modules/components/tables/_header.scss
@@ -1,0 +1,13 @@
+@use 'sass:map';
+
+@mixin generate-from($theme) {
+	$header-cell-font-size: map.get($theme, 'tables', 'cells', 'header', 'font-size');
+	$header-cell-font-weight: map.get($theme, 'tables', 'cells', 'header', 'font-weight');
+
+	.mat-mdc-header-cell {
+		font: {
+			size: $header-cell-font-size;
+			weight: $header-cell-font-weight;
+		}
+	}
+}

--- a/libs/entry-components/styles/modules/components/tables/_table-body.scss
+++ b/libs/entry-components/styles/modules/components/tables/_table-body.scss
@@ -1,11 +1,13 @@
 @use 'rows';
 @use 'sorting';
 @use 'cells';
+@use 'header';
 
 @mixin generate-from($theme) {
 	.entry-table {
 		@include rows.generate-from($theme);
 		@include sorting.generate-from($theme);
 		@include cells.generate-from($theme);
+		@include header.generate-from($theme);
 	}
 }


### PR DESCRIPTION
Improving the theme structure with an additional submap dedicated to table headers, nabling the customization of font size and weight in header cells. 
https://enigmatry.atlassian.net/browse/BP-952