### PR TITLE
BP-953: Set background for selected row in table

### DIFF
--- a/libs/entry-components/styles/modules/_default-theme.scss
+++ b/libs/entry-components/styles/modules/_default-theme.scss
@@ -50,9 +50,6 @@ $theme: (
 		)
 	),
 	tables: (
-		header: (
-			font-size: null
-		),
 		cells: (
 			edge-gap: 4px,
 			padding: null
@@ -61,7 +58,8 @@ $theme: (
 			selected-color: #FFF,
 			disabled-color: #F5F5F5,
 			odd-even-row: odd,
-			odd-even-background: #F0F0F0
+			odd-even-background: #F0F0F0,
+			odd-even-background-selected: transparent
 		),
 		contents: (
 			no-result: (

--- a/libs/entry-components/styles/modules/_default-theme.scss
+++ b/libs/entry-components/styles/modules/_default-theme.scss
@@ -62,7 +62,7 @@ $theme: (
 			disabled-color: #F5F5F5,
 			odd-even-row: odd,
 			odd-even-background: #F0F0F0,
-			odd-even-background-selected: transparent
+			odd-even-background-selected: null
 		),
 		contents: (
 			no-result: (

--- a/libs/entry-components/styles/modules/_default-theme.scss
+++ b/libs/entry-components/styles/modules/_default-theme.scss
@@ -62,13 +62,11 @@ $theme: (
 			padding: null
 		),
 		rows: (
+			selected-color: #FFF,
+			selected-background: null,
 			disabled-color: #F5F5F5,
 			odd-even-row: odd,
-			odd-even-background: #F0F0F0,
-			selected: (
-				foreground: #FFF,
-				background: null
-			),
+			odd-even-background: #F0F0F0
 		),
 		contents: (
 			no-result: (

--- a/libs/entry-components/styles/modules/_default-theme.scss
+++ b/libs/entry-components/styles/modules/_default-theme.scss
@@ -50,6 +50,9 @@ $theme: (
 		)
 	),
 	tables: (
+		header: (
+			font-size: null
+		),
 		cells: (
 			edge-gap: 4px,
 			padding: null

--- a/libs/entry-components/styles/modules/_default-theme.scss
+++ b/libs/entry-components/styles/modules/_default-theme.scss
@@ -58,11 +58,13 @@ $theme: (
 			padding: null
 		),
 		rows: (
-			selected-color: #FFF,
 			disabled-color: #F5F5F5,
 			odd-even-row: odd,
 			odd-even-background: #F0F0F0,
-			odd-even-background-selected: null
+			selected: (
+				foreground: #FFF,
+				background: null
+			),
 		),
 		contents: (
 			no-result: (

--- a/libs/entry-components/styles/modules/components/tables/_rows.scss
+++ b/libs/entry-components/styles/modules/components/tables/_rows.scss
@@ -9,14 +9,14 @@
 
 			&.selected {
 				background-color: map.get($theme, 'general', 'colors', 'primary');
-				$selected-row-background: map.get($theme, 'tables', 'rows', 'selected', 'background');
+				$selected-row-background: map.get($theme, 'tables', 'rows', 'selected-background');
 				
 				@if $selected-row-background and $selected-row-background != transparent {
 					background-color: $selected-row-background;
 				}
 				
 				.mat-mdc-cell {
-					color: map.get($theme, 'tables', 'rows', 'selected', 'foreground');
+					color: map.get($theme, 'tables', 'rows', 'selected-color');
 				}
 			}
 

--- a/libs/entry-components/styles/modules/components/tables/_rows.scss
+++ b/libs/entry-components/styles/modules/components/tables/_rows.scss
@@ -2,6 +2,9 @@
 @use '@enigmatry/scss-foundation/src/modules/lists/row-coloring' as list;
 
 @mixin generate-from($theme) {
+
+	$selected-row-background: map.get($theme, 'tables', 'rows', 'odd-even-background-selected');
+
 	.mat-mdc-row {
 		&.mdc-data-table__row {
 			@include list.row-coloring(map.get($theme, 'tables', 'rows', 'odd-even-background'),
@@ -10,6 +13,10 @@
 			&.selected {
 				background-color: map.get($theme, 'general', 'colors', 'primary');
 
+				@if $selected-row-background and $selected-row-background != transparent {
+					background-color: $selected-row-background;
+				}
+				
 				.mat-mdc-cell {
 					color: map.get($theme, 'tables', 'rows', 'selected-color');
 				}

--- a/libs/entry-components/styles/modules/components/tables/_rows.scss
+++ b/libs/entry-components/styles/modules/components/tables/_rows.scss
@@ -2,7 +2,6 @@
 @use '@enigmatry/scss-foundation/src/modules/lists/row-coloring' as list;
 
 @mixin generate-from($theme) {
-
 	$selected-row-background: map.get($theme, 'tables', 'rows', 'odd-even-background-selected');
 
 	.mat-mdc-row {

--- a/libs/entry-components/styles/modules/components/tables/_rows.scss
+++ b/libs/entry-components/styles/modules/components/tables/_rows.scss
@@ -2,8 +2,6 @@
 @use '@enigmatry/scss-foundation/src/modules/lists/row-coloring' as list;
 
 @mixin generate-from($theme) {
-	$selected-row-background: map.get($theme, 'tables', 'rows', 'odd-even-background-selected');
-
 	.mat-mdc-row {
 		&.mdc-data-table__row {
 			@include list.row-coloring(map.get($theme, 'tables', 'rows', 'odd-even-background'),
@@ -11,13 +9,14 @@
 
 			&.selected {
 				background-color: map.get($theme, 'general', 'colors', 'primary');
-
+				$selected-row-background: map.get($theme, 'tables', 'rows', 'selected', 'background');
+				
 				@if $selected-row-background and $selected-row-background != transparent {
 					background-color: $selected-row-background;
 				}
 				
 				.mat-mdc-cell {
-					color: map.get($theme, 'tables', 'rows', 'selected-color');
+					color: map.get($theme, 'tables', 'rows', 'selected', 'foreground');
 				}
 			}
 


### PR DESCRIPTION
Setting of a background color for selected row in table (if transparent is given, respect odd/even settings - ignore). Default setting should still be primary color to avoid breaking changes.

https://enigmatry.atlassian.net/browse/BP-953
