### PR TITLE
BP-1062: Scss Foundation: Grid's box sizing broken after migrating to Angular v15

### DIFF
--- a/libs/scss-foundation/src/modules/layout/_grid-core.scss
+++ b/libs/scss-foundation/src/modules/layout/_grid-core.scss
@@ -11,7 +11,7 @@ $breakpoints: () !default;
 			margin: 0 -#{$spacing};
 		}
 
-		[class ^= #{$column-prefix}], [class ^= #{$offset-prefix}] {
+		[class*='#{$column-prefix}'], [class*='#{$offset-prefix}'] {
 			box-sizing: border-box;
 			flex-shrink: 0;
 			max-width: 100%;

--- a/libs/scss-foundation/src/modules/layout/_grid-core.scss
+++ b/libs/scss-foundation/src/modules/layout/_grid-core.scss
@@ -11,7 +11,7 @@ $breakpoints: () !default;
 			margin: 0 -#{$spacing};
 		}
 
-		[class *='#{$column-prefix}'], [class *='#{$offset-prefix}'] {
+		[class*='#{$column-prefix}'], [class*='#{$offset-prefix}'] {
 			box-sizing: border-box;
 			flex-shrink: 0;
 			max-width: 100%;

--- a/libs/scss-foundation/src/modules/layout/_grid-core.scss
+++ b/libs/scss-foundation/src/modules/layout/_grid-core.scss
@@ -11,7 +11,7 @@ $breakpoints: () !default;
 			margin: 0 -#{$spacing};
 		}
 
-		[class*='#{$column-prefix}'], [class*='#{$offset-prefix}'] {
+		[class *='#{$column-prefix}'], [class *='#{$offset-prefix}'] {
 			box-sizing: border-box;
 			flex-shrink: 0;
 			max-width: 100%;

--- a/libs/scss-foundation/tests/layout/grid-core.tests.scss
+++ b/libs/scss-foundation/tests/layout/grid-core.tests.scss
@@ -27,7 +27,7 @@ $custom-breakpoints: () !default;
 					flex-wrap: wrap;
 				}
 
-				.row [class ^= 'col-'], .row [class ^= 'offset-'] {
+				.row [class *= 'col-'], .row [class *= 'offset-'] {
 					box-sizing: border-box;
 					flex-shrink: 0;
 					max-width: 100%;


### PR DESCRIPTION
Modified mixin for generating grid core and tests.

The absence of quotes in the attribute selectors when viewed in the developer tools is generally not a cause for concern. Selector is modified to look for any instance of the specified prefix

https://enigmatry.atlassian.net/browse/BP-1062