### PR TITLE
BP-1197: SCSS-Foundation: Add mixins for font size and weight

### DIFF
--- a/libs/scss-foundation/docs/modules/README.md
+++ b/libs/scss-foundation/docs/modules/README.md
@@ -17,4 +17,5 @@ Utilities are nothing more than just sass mixins that won't be included in your 
 - [Text Hover utilities](./text-hover.md)
 - [Border Radius utilities](./border-radius.md)
 - [Row Coloring utilities](./row-coloring.md)
+- [Sizing utilities](./sizes.md)
 - [Visibility utilities](./visibility.md)

--- a/libs/scss-foundation/docs/modules/README.md
+++ b/libs/scss-foundation/docs/modules/README.md
@@ -13,6 +13,7 @@ Utilities are nothing more than just sass mixins that won't be included in your 
 - [Absolute Positioning utilities](./absolute-positioning.md)
 - [Fixed Positioning utilities](./fixed-positioning.md)
 - [Text Modification utilities](./text-modification.md)
+- [Typography utilities](./typography.md)
 - [Text Hover utilities](./text-hover.md)
 - [Border Radius utilities](./border-radius.md)
 - [Row Coloring utilities](./row-coloring.md)

--- a/libs/scss-foundation/docs/modules/sizes.md
+++ b/libs/scss-foundation/docs/modules/sizes.md
@@ -4,14 +4,14 @@ Utilities for setting various sizing properties for elements.
 
 ## Set sizes
 
-@use scss-foundation/src/modules/sizes/set-sizes;
+@use scss-foundation/src/modules/sizes/set-size;
 
 ### Box dimensions
 
 - Mixin for easily applying specified dimensions for width and height of an element and optional min/max constraints to shrink depending on the screen resizing.
 
 ```
-@include set-sizes.box-dimensions(width, 100px, 50px, 200px);
+@include set-size.box-dimensions(width, 100px, 50px, 200px);
 ```
 
 Sets width property and their min and max values.
@@ -27,7 +27,7 @@ max-width: 200px;
 - A comprehensive mixin for defining both the width and height properties of an element. Sets width and height along with optional min and max values for both dimensions, providing a flexible way to manage element sizing.
 
 ```
-@include set-sizes.box-definition(300px, 200px, 250px, 350px, 150px, 250px);
+@include set-size.box-definition(300px, 200px, 250px, 350px, 150px, 250px);
 ```
 
 Sets width and height along with their respective min and max values.

--- a/libs/scss-foundation/docs/modules/typography.md
+++ b/libs/scss-foundation/docs/modules/typography.md
@@ -8,7 +8,7 @@ Utilities for setting font properties for elements.
 
 ### Set fonts
 
-Mixin for easily applying font properties such as family, size, and weight to an element. This mixin offers flexibility by allowing customization of each property, with optional arguments for family, size, and weight.
+The mixin provides a simple way to apply font properties such as family, size, and weight to an element. It allows for flexibility by enabling customization of each property through optional arguments.
 
 ```
 @include fonts.define-font('Roboto', 18px, 700);

--- a/libs/scss-foundation/docs/modules/typography.md
+++ b/libs/scss-foundation/docs/modules/typography.md
@@ -8,7 +8,7 @@ Utilities for setting font properties for elements.
 
 ### Set fonts
 
-The mixin provides a simple way to apply font properties such as family, size, and weight to an element. It allows for flexibility by enabling customization of each property through optional arguments.
+The `define-font` mixin provides a simple way to apply font properties such as family, size, and weight to an element. It allows for flexibility by enabling customization of each property. It requires **at least two** of the font properties to be provided. If this condition is not met, an error will be thrown.
 
 ```
 @include fonts.define-font('Roboto', 18px, 700);

--- a/libs/scss-foundation/docs/modules/typography.md
+++ b/libs/scss-foundation/docs/modules/typography.md
@@ -10,7 +10,7 @@ Utilities for setting font properties for elements.
 Mixin for easily applying font properties such as family, size, and weight to an element. This mixin offers flexibility by allowing customization of each property, with sensible defaults for size and weight.
 
 ```
-@include set-fonts.set-font('Roboto', 18px, 700);
+@include fonts.define-font('Roboto', 18px, 700);
 ```
 
 Sets the font family, size, and weight properties.

--- a/libs/scss-foundation/docs/modules/typography.md
+++ b/libs/scss-foundation/docs/modules/typography.md
@@ -1,0 +1,22 @@
+# Typography method
+
+Utilities for setting font properties for elements.
+
+## Fonts
+
+@use scss-foundation/src/modules/typography/fonts;
+
+### Set fonts
+Mixin for easily applying font properties such as family, size, and weight to an element. This mixin offers flexibility by allowing customization of each property, with sensible defaults for size and weight.
+
+```
+@include set-fonts.set-font('Roboto', 18px, 700);
+```
+
+Sets the font family, size, and weight properties.
+
+```
+font-family: 'Roboto';
+font-size: 18px;
+font-weight: 700;
+```

--- a/libs/scss-foundation/docs/modules/typography.md
+++ b/libs/scss-foundation/docs/modules/typography.md
@@ -7,6 +7,7 @@ Utilities for setting font properties for elements.
 @use scss-foundation/src/modules/typography/fonts;
 
 ### Set fonts
+
 Mixin for easily applying font properties such as family, size, and weight to an element. This mixin offers flexibility by allowing customization of each property, with sensible defaults for size and weight.
 
 ```

--- a/libs/scss-foundation/docs/modules/typography.md
+++ b/libs/scss-foundation/docs/modules/typography.md
@@ -8,7 +8,7 @@ Utilities for setting font properties for elements.
 
 ### Set fonts
 
-Mixin for easily applying font properties such as family, size, and weight to an element. This mixin offers flexibility by allowing customization of each property, with sensible defaults for size and weight.
+Mixin for easily applying font properties such as family, size, and weight to an element. This mixin offers flexibility by allowing customization of each property, with optional arguments for family, size, and weight.
 
 ```
 @include fonts.define-font('Roboto', 18px, 700);
@@ -20,4 +20,10 @@ Sets the font family, size, and weight properties.
 font-family: 'Roboto';
 font-size: 18px;
 font-weight: 700;
+```
+
+If you only want to set certain properties, you can skip others by using named arguments:
+
+```
+@include fonts.define-font($size: 30px, $weight: bold);
 ```

--- a/libs/scss-foundation/src/modules/_index.scss
+++ b/libs/scss-foundation/src/modules/_index.scss
@@ -4,6 +4,7 @@
 @use 'sizes';
 @use 'responsiveness';
 @use 'text';
+@use 'typography';
 @use 'lists';
 @use 'borders';
 @use 'states';

--- a/libs/scss-foundation/src/modules/typography/_fonts.scss
+++ b/libs/scss-foundation/src/modules/typography/_fonts.scss
@@ -1,0 +1,7 @@
+@mixin set-font($family, $size: 16px, $weight: 400) {
+	font: {
+		family: $family;
+		size: $size;
+		weight: $weight;
+	};
+}

--- a/libs/scss-foundation/src/modules/typography/_fonts.scss
+++ b/libs/scss-foundation/src/modules/typography/_fonts.scss
@@ -1,11 +1,9 @@
 @use 'sass-true';
+@use 'sass-true/sass/throw';
 @use '../../modules/variables' as vars;
 
 @mixin define-font($family: null, $size: null, $weight: null) {
-	@if not $family and not $size and not $weight {
-		@include sass-true.error('At least one of the font properties (family, size, weight) must be provided.');
-	}
-	@else {
+	@if ($family and $size) or ($family and $weight) or ($size and $weight) {
 		$properties: (
 			'family': $family,
 			'size': $size,
@@ -17,5 +15,12 @@
 				font-#{$property}: $value;
 			}
 		}
+	}
+	@else {
+		@include throw.error(
+			$message: 'At least two of the font properties must be provided.',
+			$source: 'define-font($family, $size, $weight)',
+			$catch: vars.$testing
+		);
 	}
 }

--- a/libs/scss-foundation/src/modules/typography/_fonts.scss
+++ b/libs/scss-foundation/src/modules/typography/_fonts.scss
@@ -1,4 +1,4 @@
-@mixin set-font($family, $size: 16px, $weight: 400) {
+@mixin define-font($family, $size: 16px, $weight: 400) {
 	font: {
 		family: $family;
 		size: $size;

--- a/libs/scss-foundation/src/modules/typography/_fonts.scss
+++ b/libs/scss-foundation/src/modules/typography/_fonts.scss
@@ -1,13 +1,17 @@
 @mixin define-font($family: null, $size: null, $weight: null) {
-	font: {
-		@if $family {
-			family: $family;
+	@if not $family and not $size and not $weight {
+		@error 'At least one of the font properties (family, size, weight) must be provided.';
+	}
+
+	$properties: (
+		'family': $family,
+		'size': $size,
+		'weight': $weight
+	);
+
+	@each $property, $value in $properties {
+		@if $value {
+			font-#{$property}: $value;
 		}
-		@if $size {
-			size: $size;
-		}
-		@if $weight {
-			weight: $weight;
-		}
-	};
+	}
 }

--- a/libs/scss-foundation/src/modules/typography/_fonts.scss
+++ b/libs/scss-foundation/src/modules/typography/_fonts.scss
@@ -1,17 +1,21 @@
+@use 'sass-true';
+@use '../../modules/variables' as vars;
+
 @mixin define-font($family: null, $size: null, $weight: null) {
 	@if not $family and not $size and not $weight {
-		@error 'At least one of the font properties (family, size, weight) must be provided.';
+		@include sass-true.error('At least one of the font properties (family, size, weight) must be provided.');
 	}
-
-	$properties: (
-		'family': $family,
-		'size': $size,
-		'weight': $weight
-	);
-
-	@each $property, $value in $properties {
-		@if $value {
-			font-#{$property}: $value;
+	@else {
+		$properties: (
+			'family': $family,
+			'size': $size,
+			'weight': $weight
+		);
+  
+		@each $property, $value in $properties {
+			@if $value {
+				font-#{$property}: $value;
+			}
 		}
 	}
 }

--- a/libs/scss-foundation/src/modules/typography/_fonts.scss
+++ b/libs/scss-foundation/src/modules/typography/_fonts.scss
@@ -1,7 +1,13 @@
-@mixin define-font($family, $size: 16px, $weight: 400) {
+@mixin define-font($family: null, $size: null, $weight: null) {
 	font: {
-		family: $family;
-		size: $size;
-		weight: $weight;
+		@if $family {
+			family: $family;
+		}
+		@if $size {
+			size: $size;
+		}
+		@if $weight {
+			weight: $weight;
+		}
 	};
 }

--- a/libs/scss-foundation/src/modules/typography/_index.scss
+++ b/libs/scss-foundation/src/modules/typography/_index.scss
@@ -1,0 +1,1 @@
+@use 'fonts';

--- a/libs/scss-foundation/tests/typography/fonts.tests.scss
+++ b/libs/scss-foundation/tests/typography/fonts.tests.scss
@@ -17,6 +17,18 @@ vars.$testing: true;
 		}
 	}
 
+	@include true.it('should set the font family and weight') {
+		@include true.assert() {
+			@include true.output() {
+				@include fonts.define-font($family: 'Arial', $weight: 400);
+			}
+			@include true.expect() {
+				font-family: 'Arial';
+				font-weight: 400;
+			}
+		}
+	}
+
 	@include true.it('should set the font family, size, and weight') {
 		@include true.assert() {
 			@include true.output() {

--- a/libs/scss-foundation/tests/typography/fonts.tests.scss
+++ b/libs/scss-foundation/tests/typography/fonts.tests.scss
@@ -42,7 +42,7 @@ vars.$testing: true;
 		}
 	}
 
-	@include true.it('should throw if only one property is defined') {
+	@include true.it('should throw an error if only one property is defined') {
 		@include true.assert() {
 			@include true.output() {
 				@include fonts.define-font('Arial');

--- a/libs/scss-foundation/tests/typography/fonts.tests.scss
+++ b/libs/scss-foundation/tests/typography/fonts.tests.scss
@@ -1,19 +1,10 @@
-@use 'sass-true/sass/true';
+@use 'sass-true' as true;
 @use '../../src/modules/typography/fonts';
+@use '../../src/modules/variables' as vars;
 
-@include true.describe('define-font()') {
+vars.$testing: true;
 
-	@include true.it('should set the font family') {
-		@include true.assert() {
-			@include true.output() {
-				@include fonts.define-font('Arial');
-			}
-			@include true.expect() {
-				font-family: 'Arial';
-			}
-		}
-	}
-
+@include true.describe('define-font($family, $size, $weight)') {
 	@include true.it('should set the font family and size') {
 		@include true.assert() {
 			@include true.output() {
@@ -35,6 +26,31 @@
 				font-family: 'Arial';
 				font-size: 18px;
 				font-weight: 700;
+			}
+		}
+	}
+
+	@include true.it('should set the font size and weight') {
+		@include true.assert() {
+			@include true.output() {
+				@include fonts.define-font($size: 18px, $weight: 700);
+			}
+			@include true.expect() {
+				font-size: 18px;
+				font-weight: 700;
+			}
+		}
+	}
+
+	@include true.it('should throw if only one property is defined') {
+		@include true.assert() {
+			@include true.output() {
+				@include fonts.define-font('Arial');
+			}
+	  
+			@include true.contains() {
+				/* ERROR [define-font($family, $size, $weight)]: */
+				/*   At least two of the font properties must be provided. */
 			}
 		}
 	}

--- a/libs/scss-foundation/tests/typography/fonts.tests.scss
+++ b/libs/scss-foundation/tests/typography/fonts.tests.scss
@@ -10,12 +10,10 @@
 			}
 			@include true.expect() {
 				font-family: 'Arial';
-				font-size: 16px;
-				font-weight: 400;
 			}
 		}
 	}
-
+  
 	@include true.it('should set the font family and size') {
 		@include true.assert() {
 			@include true.output() {
@@ -24,11 +22,10 @@
 			@include true.expect() {
 				font-family: 'Arial';
 				font-size: 14px;
-				font-weight: 400;
 			}
 		}
 	}
-
+  
 	@include true.it('should set the font family, size, and weight') {
 		@include true.assert() {
 			@include true.output() {
@@ -41,16 +38,37 @@
 			}
 		}
 	}
-
-	@include true.it('should use the default size and weight if not provided') {
+    
+	@include true.it('should set only the font size and weight') {
 		@include true.assert() {
 			@include true.output() {
-				@include fonts.define-font('Verdana');
+				@include fonts.define-font($size: 30px, $weight: 700);
 			}
 			@include true.expect() {
-				font-family: 'Verdana';
-				font-size: 16px;
-				font-weight: 400;
+				font-size: 30px;
+				font-weight: 700;
+			}
+		}
+	}
+  
+	@include true.it('should set only the font weight') {
+		@include true.assert() {
+			@include true.output() {
+				@include fonts.define-font($weight: 700);
+			}
+			@include true.expect() {
+				font-weight: 700;
+			}
+		}
+	}
+  
+	@include true.it('should set only the font size') {
+		@include true.assert() {
+			@include true.output() {
+				@include fonts.define-font($size: 20px);
+			}
+			@include true.expect() {
+				font-size: 20px;
 			}
 		}
 	}

--- a/libs/scss-foundation/tests/typography/fonts.tests.scss
+++ b/libs/scss-foundation/tests/typography/fonts.tests.scss
@@ -13,7 +13,7 @@
 			}
 		}
 	}
-  
+
 	@include true.it('should set the font family and size') {
 		@include true.assert() {
 			@include true.output() {
@@ -25,7 +25,7 @@
 			}
 		}
 	}
-  
+
 	@include true.it('should set the font family, size, and weight') {
 		@include true.assert() {
 			@include true.output() {
@@ -35,40 +35,6 @@
 				font-family: 'Arial';
 				font-size: 18px;
 				font-weight: 700;
-			}
-		}
-	}
-    
-	@include true.it('should set only the font size and weight') {
-		@include true.assert() {
-			@include true.output() {
-				@include fonts.define-font($size: 30px, $weight: 700);
-			}
-			@include true.expect() {
-				font-size: 30px;
-				font-weight: 700;
-			}
-		}
-	}
-  
-	@include true.it('should set only the font weight') {
-		@include true.assert() {
-			@include true.output() {
-				@include fonts.define-font($weight: 700);
-			}
-			@include true.expect() {
-				font-weight: 700;
-			}
-		}
-	}
-  
-	@include true.it('should set only the font size') {
-		@include true.assert() {
-			@include true.output() {
-				@include fonts.define-font($size: 20px);
-			}
-			@include true.expect() {
-				font-size: 20px;
 			}
 		}
 	}

--- a/libs/scss-foundation/tests/typography/fonts.tests.scss
+++ b/libs/scss-foundation/tests/typography/fonts.tests.scss
@@ -1,0 +1,57 @@
+@use 'sass-true/sass/true';
+@use '../../src/modules/typography/fonts';
+
+@include true.describe('set-font()') {
+
+	@include true.it('should set the font family') {
+		@include true.assert() {
+			@include true.output() {
+				@include fonts.set-font('Arial');
+			}
+			@include true.expect() {
+				font-family: 'Arial';
+				font-size: 16px;
+				font-weight: 400;
+			}
+		}
+	}
+
+	@include true.it('should set the font family and size') {
+		@include true.assert() {
+			@include true.output() {
+				@include fonts.set-font('Arial', 14px);
+			}
+			@include true.expect() {
+				font-family: 'Arial';
+				font-size: 14px;
+				font-weight: 400;
+			}
+		}
+	}
+
+	@include true.it('should set the font family, size, and weight') {
+		@include true.assert() {
+			@include true.output() {
+				@include fonts.set-font('Arial', 18px, 700);
+			}
+			@include true.expect() {
+				font-family: 'Arial';
+				font-size: 18px;
+				font-weight: 700;
+			}
+		}
+	}
+
+	@include true.it('should use the default size and weight if not provided') {
+		@include true.assert() {
+			@include true.output() {
+				@include fonts.set-font('Verdana');
+			}
+			@include true.expect() {
+				font-family: 'Verdana';
+				font-size: 16px;
+				font-weight: 400;
+			}
+		}
+	}
+}

--- a/libs/scss-foundation/tests/typography/fonts.tests.scss
+++ b/libs/scss-foundation/tests/typography/fonts.tests.scss
@@ -1,12 +1,12 @@
 @use 'sass-true/sass/true';
 @use '../../src/modules/typography/fonts';
 
-@include true.describe('set-font()') {
+@include true.describe('define-font()') {
 
 	@include true.it('should set the font family') {
 		@include true.assert() {
 			@include true.output() {
-				@include fonts.set-font('Arial');
+				@include fonts.define-font('Arial');
 			}
 			@include true.expect() {
 				font-family: 'Arial';
@@ -19,7 +19,7 @@
 	@include true.it('should set the font family and size') {
 		@include true.assert() {
 			@include true.output() {
-				@include fonts.set-font('Arial', 14px);
+				@include fonts.define-font('Arial', 14px);
 			}
 			@include true.expect() {
 				font-family: 'Arial';
@@ -32,7 +32,7 @@
 	@include true.it('should set the font family, size, and weight') {
 		@include true.assert() {
 			@include true.output() {
-				@include fonts.set-font('Arial', 18px, 700);
+				@include fonts.define-font('Arial', 18px, 700);
 			}
 			@include true.expect() {
 				font-family: 'Arial';
@@ -45,7 +45,7 @@
 	@include true.it('should use the default size and weight if not provided') {
 		@include true.assert() {
 			@include true.output() {
-				@include fonts.set-font('Verdana');
+				@include fonts.define-font('Verdana');
 			}
 			@include true.expect() {
 				font-family: 'Verdana';


### PR DESCRIPTION
https://enigmatry.atlassian.net/browse/BP-1197

We've noticed a frequent need to set font size and weight consistently across various projects, particularly in those lacking entry theming or with unique structures. To simplify our CSS and reduce redundancy, we suggest creating a single, adaptable mixin to manage both font size and weight.