### PR TITLE
BP-1293: Add theming support to new rich-text editor for basic redactor configuration

### DIFF
--- a/libs/entry-components/styles/_generator.scss
+++ b/libs/entry-components/styles/_generator.scss
@@ -8,6 +8,7 @@
 @use 'modules/components/toggle/generator' as toggle;
 @use 'modules/default-theme' as default;
 @use 'modules/vendors/angular-material/generator' as material-theme;
+@use 'modules/vendors/redactor/generator' as redactor;
 @use 'sass:map';
 @use 'partials/theming';
 
@@ -23,4 +24,5 @@
 	@include dialogs.generate-from($merged-theme);
 	@include checkboxes.generate-from($merged-theme);
 	@include toggle.generate-from($merged-theme);
+	@include redactor.generate-from($merged-theme);
 }

--- a/libs/entry-components/styles/modules/vendors/redactor/_generator.scss
+++ b/libs/entry-components/styles/modules/vendors/redactor/_generator.scss
@@ -1,0 +1,45 @@
+@use 'sass:map';
+
+$redactor-checkboxes-selector: '[data-rx-type = 'todoitem'] input:checked::before';
+
+@mixin generate-from($theme) {
+	$theming-fonts: map.get($theme, 'general', 'fonts');
+	$theming-colors: map.get($theme, 'general', 'colors');
+	$theming-checkboxes: map.get($theme, 'general', 'checkboxes');
+
+	.entry-redactor {
+		.rx-content {
+			@if $theming-colors {
+				p, li, h1, h2, h3, h4, h5, h6 {
+					color: map.get($theming-colors, 'font');
+				}
+	
+				blockquote {
+					border-left-color: map.get($theming-colors, 'primary');
+				}
+			}
+	
+			@if $theming-fonts {
+				p, li {
+					font-family: map.get($theming-fonts, 'body', 'family');
+					font-size: map.get($theming-fonts, 'body', 'size');
+				}
+			
+				h1, h2, h3, h4 {
+					font-family: map.get($theming-fonts, 'hero-titles', 'family');
+				}
+			
+				h5, h6 {
+					font-family: map.get($theming-fonts, 'titles', 'family');
+				}
+			}
+		}
+
+		@if $theming-checkboxes {
+			.rx-editor #{$redactor-checkboxes-selector} {
+				border-color: map.get($theming-checkboxes, 'background');
+				background-color: map.get($theming-checkboxes, 'background');
+			}
+		}
+	}
+}


### PR DESCRIPTION
https://enigmatry.atlassian.net/browse/BP-1293

Redactor will be used to replace CKEditor. The new rich text editor comes with some predefined CSS, and doesn't support our theming system including colors, fonts, spacings and other customizable options.

This issue introduces a mixin to override default values for the following properties enabled in the Basic Redactor configuration:

**First Iteration Includes:**
- text (paragraphs) font family, font size and color 
- list items -> same as text
- headings (h1-h4 is supported) font family
- blockquote border

**Further Considerations:**
- check if h5 & h6 should be covered
- checkboxes (on the official site there is an example with custom checkboxes to be checked)
- check elements that come with Standard and Custom Redactor configurations
- Dark/light theme support: Currently, Redactor defaults to the system theme, but this can be overridden with CSS. A better solution would involve adding a theme: 'light' option in the Redactor configuration file. Including this as a default in our Redactor repository might be beneficial since dark theme support is not yet available.
