### PR TITLE
BP-1501: Enable value formatting in Entry Search Filter component

### DIFF
--- a/apps/demo-app/src/app/examples/search-filter/search-filter/search-filter-example.component.html
+++ b/apps/demo-app/src/app/examples/search-filter/search-filter/search-filter-example.component.html
@@ -28,6 +28,11 @@
         <td mat-cell *matCellDef="let user"> {{ user.country }}</td>
     </ng-container>
 
+    <ng-container matColumnDef="score">
+        <th mat-header-cell *matHeaderCellDef> Score </th>
+        <td mat-cell *matCellDef="let user"> {{ user.score }}</td>
+    </ng-container>
+
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
     <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
 </table>

--- a/apps/demo-app/src/app/examples/search-filter/search-filter/users.service.ts
+++ b/apps/demo-app/src/app/examples/search-filter/search-filter/users.service.ts
@@ -53,6 +53,10 @@ export class UsersService {
       users = users.filter(x => x.dateOfBirth >= searchParams.dateOfBirth);
     }
 
+    if (!this.noFilterParam(searchParams, 'score')) {
+      users = users.filter(x => x.score === searchParams['score']);
+    }
+
     return of(users);
   }
 

--- a/apps/demo-app/src/app/examples/search-filter/search-filter/users.ts
+++ b/apps/demo-app/src/app/examples/search-filter/search-filter/users.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines */
+/* eslint-disable @typescript-eslint/no-magic-numbers */
 enum Occupation {
     unknown = 0,
     electrician = 1,
@@ -33,14 +35,15 @@ enum Country {
 }
 
 interface User {
-    id?: string;
-    userName?: string;
-    firstName?: string;
-    lastName?: string;
-    dateOfBirth?: Date;
+    id: string;
+    userName: string;
+    firstName: string;
+    lastName: string;
+    dateOfBirth: Date;
     occupation: Occupation;
-    lastLogin?: Date;
-    country?: Country;
+    lastLogin: Date;
+    country: Country;
+    score: string;
 }
 
 const LIST_OF_USERS: User[] = [
@@ -52,7 +55,8 @@ const LIST_OF_USERS: User[] = [
         dateOfBirth: new Date(1992, 3, 3),
         occupation: Occupation.electrician,
         lastLogin: new Date(),
-        country: Country.netherlands
+        country: Country.netherlands,
+        score: '4.50'
     },
     {
         id: '2',
@@ -62,7 +66,8 @@ const LIST_OF_USERS: User[] = [
         dateOfBirth: new Date(1985, 5, 26),
         occupation: Occupation.unknown,
         lastLogin: new Date(),
-        country: Country.serbia
+        country: Country.serbia,
+        score: '3.75'
     },
     {
         id: '3',
@@ -72,7 +77,8 @@ const LIST_OF_USERS: User[] = [
         dateOfBirth: new Date(1977, 9, 14),
         occupation: Occupation.baker,
         lastLogin: new Date(),
-        country: Country.argentina
+        country: Country.argentina,
+        score: '4.20'
     },
     {
         id: '4',
@@ -82,7 +88,8 @@ const LIST_OF_USERS: User[] = [
         dateOfBirth: new Date(2000, 2, 8),
         occupation: Occupation.plumber,
         lastLogin: new Date(),
-        country: Country.netherlands
+        country: Country.netherlands,
+        score: '3.90'
     },
     {
         id: '5',
@@ -92,7 +99,8 @@ const LIST_OF_USERS: User[] = [
         dateOfBirth: new Date(1965, 11, 11),
         occupation: Occupation.teacher,
         lastLogin: new Date(),
-        country: Country.india
+        country: Country.india,
+        score: '0.80'
     },
     {
         id: '6',
@@ -102,7 +110,8 @@ const LIST_OF_USERS: User[] = [
         dateOfBirth: new Date(1996, 7, 22),
         occupation: Occupation.baker,
         lastLogin: new Date(),
-        country: Country.unitedKingdom
+        country: Country.unitedKingdom,
+        score: '2.50'
     },
     {
         id: '7',
@@ -112,7 +121,8 @@ const LIST_OF_USERS: User[] = [
         dateOfBirth: new Date(1983, 0, 15),
         occupation: Occupation.soldier,
         lastLogin: new Date(),
-        country: Country.unitedStates
+        country: Country.unitedStates,
+        score: '1.25'
     },
     {
         id: '8',
@@ -122,7 +132,8 @@ const LIST_OF_USERS: User[] = [
         dateOfBirth: new Date(1973, 4, 19),
         occupation: Occupation.baker,
         lastLogin: new Date(),
-        country: Country.france
+        country: Country.france,
+        score: '3.00'
     },
     {
         id: '9',
@@ -132,7 +143,8 @@ const LIST_OF_USERS: User[] = [
         dateOfBirth: new Date(1987, 6, 30),
         occupation: Occupation.doctor,
         lastLogin: new Date(),
-        country: Country.germany
+        country: Country.germany,
+        score: '4.75'
     },
     {
         id: '10',
@@ -142,7 +154,8 @@ const LIST_OF_USERS: User[] = [
         dateOfBirth: new Date(1994, 1, 21),
         occupation: Occupation.painter,
         lastLogin: new Date(),
-        country: Country.spain
+        country: Country.spain,
+        score: '4.75'
     },
     {
         id: '11',
@@ -152,13 +165,14 @@ const LIST_OF_USERS: User[] = [
         dateOfBirth: new Date(1951, 1, 1),
         occupation: Occupation.teacher,
         lastLogin: new Date(),
-        country: Country.indonesia
+        country: Country.indonesia,
+        score: '3.00'
     }
 ];
 
 export {
     Occupation,
-    Country,
-    User,
-    LIST_OF_USERS
+    Country, LIST_OF_USERS
 };
+
+export type { User };

--- a/apps/demo-app/src/assets/api/@enigmatry/entry-components/button/public-api.md
+++ b/apps/demo-app/src/assets/api/@enigmatry/entry-components/button/public-api.md
@@ -10,8 +10,8 @@ Used to provide button configuration on module or application level.
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| `cancel` | `MatButtonConfig` | Cancel button configuration |  |
-| `submit` | `MatButtonConfig` | Submit button configuration |  |
+| <a id="cancel"></a> `cancel` | `MatButtonConfig` | Cancel button configuration |  |
+| <a id="submit"></a> `submit` | `MatButtonConfig` | Submit button configuration |  |
 
 ## Variables
 
@@ -35,7 +35,9 @@ Can be used to provide custom button configuration.
 
 #### Parameters
 
-• **config**: `Partial`\<[`EntryButtonConfig`](public-api.md#entrybuttonconfig)\>
+##### config
+
+`Partial`\<[`EntryButtonConfig`](public-api.md#entrybuttonconfig)\>
 
 #### Returns
 

--- a/apps/demo-app/src/assets/api/@enigmatry/entry-components/dialog/public-api.md
+++ b/apps/demo-app/src/assets/api/@enigmatry/entry-components/dialog/public-api.md
@@ -16,15 +16,15 @@ Base Entry dialog component. Must be extended when building custom dialogs.
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| `buttonsAlignment` | [`EntryDialogButtonsAlignment`](public-api.md#entrydialogbuttonsalignment) | Dialog buttons horizontal alignment |  |
-| `buttonsTemplate` | `TemplateRef`\<`any`\> | Provide custom buttons template |  |
-| `cancelButtonText` | `string` | Cancel button label |  |
-| `confirmButtonText` | `string` | Confirm button label |  |
-| `disableConfirm` | `boolean` | Enable or disable dialog confirm button |  |
-| `hideButtons` | `boolean` | Show or hide dialog buttons |  |
-| `hideCancel` | `boolean` | Show or hide dialog cancel button |  |
-| `hideClose` | `boolean` | Show or hide dialog close button |  |
-| `title` | `string` | Dialog header title |  |
+| <a id="buttonsalignment"></a> `buttonsAlignment` | [`EntryDialogButtonsAlignment`](public-api.md#entrydialogbuttonsalignment) | Dialog buttons horizontal alignment |  |
+| <a id="buttonstemplate"></a> `buttonsTemplate` | `TemplateRef`\<`any`\> | Provide custom buttons template |  |
+| <a id="cancelbuttontext"></a> `cancelButtonText` | `string` | Cancel button label |  |
+| <a id="confirmbuttontext"></a> `confirmButtonText` | `string` | Confirm button label |  |
+| <a id="disableconfirm"></a> `disableConfirm` | `boolean` | Enable or disable dialog confirm button |  |
+| <a id="hidebuttons"></a> `hideButtons` | `boolean` | Show or hide dialog buttons |  |
+| <a id="hidecancel"></a> `hideCancel` | `boolean` | Show or hide dialog cancel button |  |
+| <a id="hideclose"></a> `hideClose` | `boolean` | Show or hide dialog close button |  |
+| <a id="title"></a> `title` | `string` | Dialog header title |  |
 
 ***
 
@@ -36,11 +36,11 @@ Used to provide default configurations on module level.
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| `buttonsAlignment` | [`EntryDialogButtonsAlignment`](public-api.md#entrydialogbuttonsalignment) | Dialog buttons horizontal alignment (default 'align-right') |  |
-| `cancelButtonText` | `string` | Cancel button label (default 'Cancel') |  |
-| `confirmButtonText` | `string` | Confirm button label (default 'Ok') |  |
-| `disableClose` | `boolean` | Disable closing dialog when pressing escape or clicking on backdrop (default false) |  |
-| `hideClose` | `boolean` | Determines if close button is visible (default is true) |  |
+| <a id="buttonsalignment-1"></a> `buttonsAlignment` | [`EntryDialogButtonsAlignment`](public-api.md#entrydialogbuttonsalignment) | Dialog buttons horizontal alignment (default 'align-right') |  |
+| <a id="cancelbuttontext-1"></a> `cancelButtonText` | `string` | Cancel button label (default 'Cancel') |  |
+| <a id="confirmbuttontext-1"></a> `confirmButtonText` | `string` | Confirm button label (default 'Ok') |  |
+| <a id="disableclose"></a> `disableClose` | `boolean` | Disable closing dialog when pressing escape or clicking on backdrop (default false) |  |
+| <a id="hideclose-1"></a> `hideClose` | `boolean` | Determines if close button is visible (default is true) |  |
 
 ***
 
@@ -68,19 +68,27 @@ Opens dialog with custom component.
 
 ###### Parameters
 
-• **component**: `Type`\<[`EntryDialogComponent`](public-api.md#entrydialogcomponent)\>
+###### component
+
+`Type`\<[`EntryDialogComponent`](public-api.md#entrydialogcomponent)\>
 
 Dialog custom component implementation
 
-• **data**: `unknown` = `undefined`
+###### data
+
+`unknown` = `undefined`
 
 Optional parameter used to supply component with input parameters
 
-• **disableClose**: `boolean` = `undefined`
+###### disableClose
+
+`boolean` = `undefined`
 
 Optional parameter that disable closing dialog when pressing escape or clicking on backdrop
 
-• **cssClass**: `string` = `''`
+###### cssClass
+
+`string` = `''`
 
 Optional parameter used to set custom class to Material overlay pane
 
@@ -98,7 +106,9 @@ Opens alert dialog.
 
 ###### Parameters
 
-• **data**: `Partial`\<[`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata)\>
+###### data
+
+`Partial`\<[`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata)\>
 
 Contains title, message and optional confirm button text
 
@@ -116,7 +126,9 @@ Opens confirm dialog.
 
 ###### Parameters
 
-• **data**: `Partial`\<[`IEntryConfirmDialogData`](public-api.md#ientryconfirmdialogdata)\>
+###### data
+
+`Partial`\<[`IEntryConfirmDialogData`](public-api.md#ientryconfirmdialogdata)\>
 
 Contains title, message and optional confirm/cancel buttons text
 
@@ -134,7 +146,9 @@ Opens error dialog.
 
 ###### Parameters
 
-• **data**: `Partial`\<[`IEntryErrorDialogData`](public-api.md#ientryerrordialogdata)\>
+###### data
+
+`Partial`\<[`IEntryErrorDialogData`](public-api.md#ientryerrordialogdata)\>
 
 Contains title, errors and optional confirm button text
 
@@ -159,12 +173,12 @@ Alert dialog data.
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| `buttonsAlignment` | [`EntryDialogButtonsAlignment`](public-api.md#entrydialogbuttonsalignment) | Optional dialog buttons horizontal alignment |  |
-| `confirmText?` | `string` | Optional dialog confirm text label |  |
-| `disableClose?` | `boolean` | Optionally disable closing dialog when pressing escape or clicking on backdrop |  |
-| `hideClose` | `boolean` | Optionally show or hide dialog close button |  |
-| `message` | `string` | Dialog content message |  |
-| `title` | `string` | Dialog header title |  |
+| <a id="buttonsalignment-2"></a> `buttonsAlignment` | [`EntryDialogButtonsAlignment`](public-api.md#entrydialogbuttonsalignment) | Optional dialog buttons horizontal alignment |  |
+| <a id="confirmtext"></a> `confirmText?` | `string` | Optional dialog confirm text label |  |
+| <a id="disableclose-1"></a> `disableClose?` | `boolean` | Optionally disable closing dialog when pressing escape or clicking on backdrop |  |
+| <a id="hideclose-2"></a> `hideClose` | `boolean` | Optionally show or hide dialog close button |  |
+| <a id="message"></a> `message` | `string` | Dialog content message |  |
+| <a id="title-1"></a> `title` | `string` | Dialog header title |  |
 
 ***
 
@@ -180,13 +194,13 @@ Confirm dialog data. Extends IEntryAlertDialogData.
 
 | Property | Type | Description | Inherited from | Defined in |
 | ------ | ------ | ------ | ------ | ------ |
-| `buttonsAlignment` | [`EntryDialogButtonsAlignment`](public-api.md#entrydialogbuttonsalignment) | Optional dialog buttons horizontal alignment | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).`buttonsAlignment` |  |
-| `cancelText?` | `string` | Optional dialog cancel text label | - |  |
-| `confirmText?` | `string` | Optional dialog confirm text label | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).`confirmText` |  |
-| `disableClose?` | `boolean` | Optionally disable closing dialog when pressing escape or clicking on backdrop | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).`disableClose` |  |
-| `hideClose` | `boolean` | Optionally show or hide dialog close button | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).`hideClose` |  |
-| `message` | `string` | Dialog content message | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).`message` |  |
-| `title` | `string` | Dialog header title | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).`title` |  |
+| <a id="buttonsalignment-3"></a> `buttonsAlignment` | [`EntryDialogButtonsAlignment`](public-api.md#entrydialogbuttonsalignment) | Optional dialog buttons horizontal alignment | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).[`buttonsAlignment`](public-api.md#buttonsalignment-2) |  |
+| <a id="canceltext"></a> `cancelText?` | `string` | Optional dialog cancel text label | - |  |
+| <a id="confirmtext-1"></a> `confirmText?` | `string` | Optional dialog confirm text label | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).[`confirmText`](public-api.md#confirmtext) |  |
+| <a id="disableclose-2"></a> `disableClose?` | `boolean` | Optionally disable closing dialog when pressing escape or clicking on backdrop | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).[`disableClose`](public-api.md#disableclose-1) |  |
+| <a id="hideclose-3"></a> `hideClose` | `boolean` | Optionally show or hide dialog close button | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).[`hideClose`](public-api.md#hideclose-2) |  |
+| <a id="message-1"></a> `message` | `string` | Dialog content message | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).[`message`](public-api.md#message) |  |
+| <a id="title-2"></a> `title` | `string` | Dialog header title | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).[`title`](public-api.md#title-1) |  |
 
 ***
 
@@ -202,13 +216,13 @@ Error dialog data.
 
 | Property | Type | Description | Inherited from | Defined in |
 | ------ | ------ | ------ | ------ | ------ |
-| `buttonsAlignment` | [`EntryDialogButtonsAlignment`](public-api.md#entrydialogbuttonsalignment) | Optional dialog buttons horizontal alignment | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).`buttonsAlignment` |  |
-| `confirmText?` | `string` | Optional dialog confirm text label | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).`confirmText` |  |
-| `disableClose?` | `boolean` | Optionally disable closing dialog when pressing escape or clicking on backdrop | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).`disableClose` |  |
-| `errors` | `string`[] \| [`IValidationProblemDetails`](../validation/public-api.md#ivalidationproblemdetails) | Errors to display | - |  |
-| `hideClose` | `boolean` | Optionally show or hide dialog close button | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).`hideClose` |  |
-| `message` | `string` | Dialog content message | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).`message` |  |
-| `title` | `string` | Dialog header title | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).`title` |  |
+| <a id="buttonsalignment-4"></a> `buttonsAlignment` | [`EntryDialogButtonsAlignment`](public-api.md#entrydialogbuttonsalignment) | Optional dialog buttons horizontal alignment | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).[`buttonsAlignment`](public-api.md#buttonsalignment-2) |  |
+| <a id="confirmtext-2"></a> `confirmText?` | `string` | Optional dialog confirm text label | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).[`confirmText`](public-api.md#confirmtext) |  |
+| <a id="disableclose-3"></a> `disableClose?` | `boolean` | Optionally disable closing dialog when pressing escape or clicking on backdrop | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).[`disableClose`](public-api.md#disableclose-1) |  |
+| <a id="errors"></a> `errors` | `string`[] \| [`IValidationProblemDetails`](../validation/public-api.md#ivalidationproblemdetails) | Errors to display | - |  |
+| <a id="hideclose-4"></a> `hideClose` | `boolean` | Optionally show or hide dialog close button | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).[`hideClose`](public-api.md#hideclose-2) |  |
+| <a id="message-2"></a> `message` | `string` | Dialog content message | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).[`message`](public-api.md#message) |  |
+| <a id="title-3"></a> `title` | `string` | Dialog header title | [`IEntryAlertDialogData`](public-api.md#ientryalertdialogdata).[`title`](public-api.md#title-1) |  |
 
 ## Type Aliases
 
@@ -243,7 +257,9 @@ Can be used to provide entry dialog configuration.
 
 #### Parameters
 
-• **config**: `Partial`\<[`EntryDialogConfig`](public-api.md#entrydialogconfig)\>
+##### config
+
+`Partial`\<[`EntryDialogConfig`](public-api.md#entrydialogconfig)\>
 
 #### Returns
 

--- a/apps/demo-app/src/assets/api/@enigmatry/entry-components/search-filter/public-api.md
+++ b/apps/demo-app/src/assets/api/@enigmatry/entry-components/search-filter/public-api.md
@@ -20,17 +20,18 @@ SelectOption<T>
 
 | Property | Type | Default value | Description | Overrides | Inherited from | Defined in |
 | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| `controlType` | `ControlType` | `ControlType.autocomplete` | Control type to be overridden in implementing class, used to render the proper input type e.g. 'text-input' | [`SearchFilterBase`](public-api.md#searchfilterbaset).`controlType` | - |  |
-| `debounceTime` | `number` | `undefined` | Delay in typing before triggering the search function in milliseconds(default is 300) | - | - |  |
-| `formControl` | `FormControl`\<[`SelectOption`](public-api.md#selectoptiont)\<`T`\>\> | `undefined` | A reference to the form control it represents | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`formControl` |  |
-| `key` | `string` | `undefined` | Unique search-filter input key | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`key` |  |
-| `label` | `string` | `undefined` | Label text to be displayed for the search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`label` |  |
-| `maxLength` | `number` | `undefined` | Max text length to be entered in the input component (default is 256) | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`maxLength` |  |
-| `minimumCharacters` | `number` | `undefined` | Minimum number of characters that must enter to trigger the search function(default is 3) | - | - |  |
-| `placeholder` | `string` | `undefined` | Placeholder text for search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`placeholder` |  |
-| `search` | (`input`: `string`) => `Observable`\<[`SelectOption`](public-api.md#selectoptiont)\<`T`\>[]\> | `undefined` | Callback function for autocomplete options | - | - |  |
-| `type` | `string` | `undefined` | Type of input control e.g. 'text' or 'email' | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`type` |  |
-| `value` | [`SelectOption`](public-api.md#selectoptiont)\<`T`\> | `undefined` | Default value to be displayed/selected in the input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`value` |  |
+| <a id="controltype"></a> `controlType` | `ControlType` | `ControlType.autocomplete` | Control type to be overridden in implementing class, used to render the proper input type e.g. 'text-input' | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`controlType`](public-api.md#controltype-3) | - |  |
+| <a id="debouncetime"></a> `debounceTime` | `number` | `undefined` | Delay in typing before triggering the search function in milliseconds(default is 300) | - | - |  |
+| <a id="formatvalue"></a> `formatValue` | (`value`: [`SelectOption`](public-api.md#selectoptiont)\<`T`\>) => [`SelectOption`](public-api.md#selectoptiont)\<`T`\> | `undefined` | Optional function to format the value before displaying it in the input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`formatValue`](public-api.md#formatvalue-3) |  |
+| <a id="formcontrol"></a> `formControl` | `FormControl`\<[`SelectOption`](public-api.md#selectoptiont)\<`T`\>\> | `undefined` | A reference to the form control it represents | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`formControl`](public-api.md#formcontrol-3) |  |
+| <a id="key"></a> `key` | `string` | `undefined` | Unique search-filter input key | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`key`](public-api.md#key-3) |  |
+| <a id="label"></a> `label` | `string` | `undefined` | Label text to be displayed for the search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`label`](public-api.md#label-3) |  |
+| <a id="maxlength"></a> `maxLength` | `number` | `undefined` | Max text length to be entered in the input component (default is 256) | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`maxLength`](public-api.md#maxlength-3) |  |
+| <a id="minimumcharacters"></a> `minimumCharacters` | `number` | `undefined` | Minimum number of characters that must enter to trigger the search function(default is 3) | - | - |  |
+| <a id="placeholder"></a> `placeholder` | `string` | `undefined` | Placeholder text for search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`placeholder`](public-api.md#placeholder-3) |  |
+| <a id="search"></a> `search` | (`input`: `string`) => `Observable`\<[`SelectOption`](public-api.md#selectoptiont)\<`T`\>[]\> | `undefined` | Callback function for autocomplete options | - | - |  |
+| <a id="type"></a> `type` | `string` | `undefined` | Type of input control e.g. 'text' or 'email' | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`type`](public-api.md#type-3) |  |
+| <a id="value"></a> `value` | [`SelectOption`](public-api.md#selectoptiont)\<`T`\> | `undefined` | Default value to be displayed/selected in the input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`value`](public-api.md#value-3) |  |
 
 ***
 
@@ -50,14 +51,15 @@ Search filter date input filed configuration.
 
 | Property | Type | Default value | Description | Overrides | Inherited from | Defined in |
 | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| `controlType` | `ControlType` | `ControlType.date` | Control type to be overridden in implementing class, used to render the proper input type e.g. 'text-input' | [`SearchFilterBase`](public-api.md#searchfilterbaset).`controlType` | - |  |
-| `formControl` | `FormControl`\<`D`\> | `undefined` | A reference to the form control it represents | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`formControl` |  |
-| `key` | `string` | `undefined` | Unique search-filter input key | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`key` |  |
-| `label` | `string` | `undefined` | Label text to be displayed for the search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`label` |  |
-| `maxLength` | `number` | `undefined` | Max text length to be entered in the input component (default is 256) | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`maxLength` |  |
-| `placeholder` | `string` | `undefined` | Placeholder text for search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`placeholder` |  |
-| `type` | `string` | `undefined` | Type of input control e.g. 'text' or 'email' | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`type` |  |
-| `value` | `D` | `undefined` | Default value to be displayed/selected in the input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`value` |  |
+| <a id="controltype-1"></a> `controlType` | `ControlType` | `ControlType.date` | Control type to be overridden in implementing class, used to render the proper input type e.g. 'text-input' | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`controlType`](public-api.md#controltype-3) | - |  |
+| <a id="formatvalue-1"></a> `formatValue` | (`value`: `D`) => `D` | `undefined` | Optional function to format the value before displaying it in the input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`formatValue`](public-api.md#formatvalue-3) |  |
+| <a id="formcontrol-1"></a> `formControl` | `FormControl`\<`D`\> | `undefined` | A reference to the form control it represents | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`formControl`](public-api.md#formcontrol-3) |  |
+| <a id="key-1"></a> `key` | `string` | `undefined` | Unique search-filter input key | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`key`](public-api.md#key-3) |  |
+| <a id="label-1"></a> `label` | `string` | `undefined` | Label text to be displayed for the search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`label`](public-api.md#label-3) |  |
+| <a id="maxlength-1"></a> `maxLength` | `number` | `undefined` | Max text length to be entered in the input component (default is 256) | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`maxLength`](public-api.md#maxlength-3) |  |
+| <a id="placeholder-1"></a> `placeholder` | `string` | `undefined` | Placeholder text for search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`placeholder`](public-api.md#placeholder-3) |  |
+| <a id="type-1"></a> `type` | `string` | `undefined` | Type of input control e.g. 'text' or 'email' | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`type`](public-api.md#type-3) |  |
+| <a id="value-1"></a> `value` | `D` | `undefined` | Default value to be displayed/selected in the input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`value`](public-api.md#value-3) |  |
 
 ***
 
@@ -77,14 +79,15 @@ Search filter date time input filed configuration.
 
 | Property | Type | Default value | Description | Overrides | Inherited from | Defined in |
 | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| `controlType` | `ControlType` | `ControlType.dateTime` | Control type to be overridden in implementing class, used to render the proper input type e.g. 'text-input' | [`SearchFilterBase`](public-api.md#searchfilterbaset).`controlType` | - |  |
-| `formControl` | `FormControl`\<`D`\> | `undefined` | A reference to the form control it represents | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`formControl` |  |
-| `key` | `string` | `undefined` | Unique search-filter input key | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`key` |  |
-| `label` | `string` | `undefined` | Label text to be displayed for the search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`label` |  |
-| `maxLength` | `number` | `undefined` | Max text length to be entered in the input component (default is 256) | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`maxLength` |  |
-| `placeholder` | `string` | `undefined` | Placeholder text for search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`placeholder` |  |
-| `type` | `string` | `undefined` | Type of input control e.g. 'text' or 'email' | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`type` |  |
-| `value` | `D` | `undefined` | Default value to be displayed/selected in the input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`value` |  |
+| <a id="controltype-2"></a> `controlType` | `ControlType` | `ControlType.dateTime` | Control type to be overridden in implementing class, used to render the proper input type e.g. 'text-input' | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`controlType`](public-api.md#controltype-3) | - |  |
+| <a id="formatvalue-2"></a> `formatValue` | (`value`: `D`) => `D` | `undefined` | Optional function to format the value before displaying it in the input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`formatValue`](public-api.md#formatvalue-3) |  |
+| <a id="formcontrol-2"></a> `formControl` | `FormControl`\<`D`\> | `undefined` | A reference to the form control it represents | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`formControl`](public-api.md#formcontrol-3) |  |
+| <a id="key-2"></a> `key` | `string` | `undefined` | Unique search-filter input key | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`key`](public-api.md#key-3) |  |
+| <a id="label-2"></a> `label` | `string` | `undefined` | Label text to be displayed for the search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`label`](public-api.md#label-3) |  |
+| <a id="maxlength-2"></a> `maxLength` | `number` | `undefined` | Max text length to be entered in the input component (default is 256) | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`maxLength`](public-api.md#maxlength-3) |  |
+| <a id="placeholder-2"></a> `placeholder` | `string` | `undefined` | Placeholder text for search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`placeholder`](public-api.md#placeholder-3) |  |
+| <a id="type-2"></a> `type` | `string` | `undefined` | Type of input control e.g. 'text' or 'email' | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`type`](public-api.md#type-3) |  |
+| <a id="value-2"></a> `value` | `D` | `undefined` | Default value to be displayed/selected in the input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`value`](public-api.md#value-3) |  |
 
 ***
 
@@ -95,15 +98,31 @@ Entry SearchFilter component.
 #### Implements
 
 - `OnInit`
+- `OnDestroy`
 
 #### Properties
 
 | Property | Type | Default value | Description | Defined in |
 | ------ | ------ | ------ | ------ | ------ |
-| `searchFilterChange` | `EventEmitter`\<[`SearchFilterParams`](public-api.md#searchfilterparams)\> | `undefined` | Emits the change in SearchFilterParams so the containing component can apply them and retrieve the filtered results. |  |
-| `searchFilters` | [`SearchFilterBase`](public-api.md#searchfilterbaset)\<`any`\>[] | `[]` | Configuration of the search filters inputs that will be displayed in the search-filter component. |  |
+| <a id="searchfilterchange"></a> `searchFilterChange` | `EventEmitter`\<[`SearchFilterParams`](public-api.md#searchfilterparams)\> | `undefined` | Emits the change in SearchFilterParams so the containing component can apply them and retrieve the filtered results. |  |
+| <a id="searchfilters"></a> `searchFilters` | [`SearchFilterBase`](public-api.md#searchfilterbaset)\<`any`\>[] | `[]` | Configuration of the search filters inputs that will be displayed in the search-filter component. |  |
 
 #### Methods
+
+##### ngOnDestroy()
+
+> **ngOnDestroy**(): `void`
+
+A callback method that performs custom clean-up, invoked immediately
+before a directive, pipe, or service instance is destroyed.
+
+###### Returns
+
+`void`
+
+###### Implementation of
+
+`OnDestroy.ngOnDestroy`
 
 ##### ngOnInit()
 
@@ -133,8 +152,8 @@ Used to provide entry search filter configuration on module level.
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| `applyButtonText` | `string` | Apply search filters button label (default 'Apply') |  |
-| `noneSelectedOptionText` | `string` | Label for 'none selected' select filter option |  |
+| <a id="applybuttontext"></a> `applyButtonText` | `string` | Apply search filters button label (default 'Apply') |  |
+| <a id="noneselectedoptiontext"></a> `noneSelectedOptionText` | `string` | Label for 'none selected' select filter option |  |
 
 ***
 
@@ -158,14 +177,15 @@ Base Entry search filter input component.
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| `controlType` | `ControlType` | Control type to be overridden in implementing class, used to render the proper input type e.g. 'text-input' |  |
-| `formControl` | `FormControl`\<`T`\> | A reference to the form control it represents |  |
-| `key` | `string` | Unique search-filter input key |  |
-| `label` | `string` | Label text to be displayed for the search-filter input control |  |
-| `maxLength` | `number` | Max text length to be entered in the input component (default is 256) |  |
-| `placeholder` | `string` | Placeholder text for search-filter input control |  |
-| `type` | `string` | Type of input control e.g. 'text' or 'email' |  |
-| `value` | `T` | Default value to be displayed/selected in the input control |  |
+| <a id="controltype-3"></a> `controlType` | `ControlType` | Control type to be overridden in implementing class, used to render the proper input type e.g. 'text-input' |  |
+| <a id="formatvalue-3"></a> `formatValue` | (`value`: `T`) => `T` | Optional function to format the value before displaying it in the input control |  |
+| <a id="formcontrol-3"></a> `formControl` | `FormControl`\<`T`\> | A reference to the form control it represents |  |
+| <a id="key-3"></a> `key` | `string` | Unique search-filter input key |  |
+| <a id="label-3"></a> `label` | `string` | Label text to be displayed for the search-filter input control |  |
+| <a id="maxlength-3"></a> `maxLength` | `number` | Max text length to be entered in the input component (default is 256) |  |
+| <a id="placeholder-3"></a> `placeholder` | `string` | Placeholder text for search-filter input control |  |
+| <a id="type-3"></a> `type` | `string` | Type of input control e.g. 'text' or 'email' |  |
+| <a id="value-3"></a> `value` | `T` | Default value to be displayed/selected in the input control |  |
 
 ***
 
@@ -181,8 +201,8 @@ Model used to populate select or autocomplete options.
 
 | Property | Modifier | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ | ------ |
-| `key` | `public` | `T` | Key used as a value for selected option |  |
-| `label` | `public` | `string` | String value used as display label of select option |  |
+| <a id="key-4"></a> `key` | `public` | `T` | Key used as a value for selected option |  |
+| <a id="label-4"></a> `label` | `public` | `string` | String value used as display label of select option |  |
 
 ***
 
@@ -203,17 +223,18 @@ or observable (dynamic) list (`options$`).
 
 | Property | Type | Default value | Description | Overrides | Inherited from | Defined in |
 | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| `controlType` | `ControlType` | `ControlType.select` | Control type to be overridden in implementing class, used to render the proper input type e.g. 'text-input' | [`SearchFilterBase`](public-api.md#searchfilterbaset).`controlType` | - |  |
-| `formControl` | `FormControl`\<`T`\> | `undefined` | A reference to the form control it represents | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`formControl` |  |
-| `key` | `string` | `undefined` | Unique search-filter input key | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`key` |  |
-| `label` | `string` | `undefined` | Label text to be displayed for the search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`label` |  |
-| `maxLength` | `number` | `undefined` | Max text length to be entered in the input component (default is 256) | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`maxLength` |  |
-| `multiSelect` | `boolean` | `true` | Enables selection of multiple options (default is true). If it is set to false, 'none selected' option becomes available as a first option. | - | - |  |
-| `options` | [`SelectOption`](public-api.md#selectoptiont)\<`T`\>[] | `[]` | Fixed list of select filter options (default is empty list) | - | - |  |
-| `options$` | `Observable`\<[`SelectOption`](public-api.md#selectoptiont)\<`T`\>[]\> | `undefined` | Observable (dynamic) list of select filter options | - | - |  |
-| `placeholder` | `string` | `undefined` | Placeholder text for search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`placeholder` |  |
-| `type` | `string` | `undefined` | Type of input control e.g. 'text' or 'email' | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`type` |  |
-| `value` | `T` | `undefined` | Default value to be displayed/selected in the input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`value` |  |
+| <a id="controltype-4"></a> `controlType` | `ControlType` | `ControlType.select` | Control type to be overridden in implementing class, used to render the proper input type e.g. 'text-input' | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`controlType`](public-api.md#controltype-3) | - |  |
+| <a id="formatvalue-4"></a> `formatValue` | (`value`: `T`) => `T` | `undefined` | Optional function to format the value before displaying it in the input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`formatValue`](public-api.md#formatvalue-3) |  |
+| <a id="formcontrol-4"></a> `formControl` | `FormControl`\<`T`\> | `undefined` | A reference to the form control it represents | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`formControl`](public-api.md#formcontrol-3) |  |
+| <a id="key-5"></a> `key` | `string` | `undefined` | Unique search-filter input key | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`key`](public-api.md#key-3) |  |
+| <a id="label-5"></a> `label` | `string` | `undefined` | Label text to be displayed for the search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`label`](public-api.md#label-3) |  |
+| <a id="maxlength-4"></a> `maxLength` | `number` | `undefined` | Max text length to be entered in the input component (default is 256) | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`maxLength`](public-api.md#maxlength-3) |  |
+| <a id="multiselect"></a> `multiSelect` | `boolean` | `true` | Enables selection of multiple options (default is true). If it is set to false, 'none selected' option becomes available as a first option. | - | - |  |
+| <a id="options"></a> `options` | [`SelectOption`](public-api.md#selectoptiont)\<`T`\>[] | `[]` | Fixed list of select filter options (default is empty list) | - | - |  |
+| <a id="options$"></a> `options$` | `Observable`\<[`SelectOption`](public-api.md#selectoptiont)\<`T`\>[]\> | `undefined` | Observable (dynamic) list of select filter options | - | - |  |
+| <a id="placeholder-4"></a> `placeholder` | `string` | `undefined` | Placeholder text for search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`placeholder`](public-api.md#placeholder-3) |  |
+| <a id="type-4"></a> `type` | `string` | `undefined` | Type of input control e.g. 'text' or 'email' | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`type`](public-api.md#type-3) |  |
+| <a id="value-4"></a> `value` | `T` | `undefined` | Default value to be displayed/selected in the input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`value`](public-api.md#value-3) |  |
 
 ***
 
@@ -229,14 +250,15 @@ Search filter text input filed configuration.
 
 | Property | Type | Default value | Description | Overrides | Inherited from | Defined in |
 | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| `controlType` | `ControlType` | `ControlType.text` | Control type to be overridden in implementing class, used to render the proper input type e.g. 'text-input' | [`SearchFilterBase`](public-api.md#searchfilterbaset).`controlType` | - |  |
-| `formControl` | `FormControl`\<`string`\> | `undefined` | A reference to the form control it represents | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`formControl` |  |
-| `key` | `string` | `undefined` | Unique search-filter input key | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`key` |  |
-| `label` | `string` | `undefined` | Label text to be displayed for the search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`label` |  |
-| `maxLength` | `number` | `undefined` | Max text length to be entered in the input component (default is 256) | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`maxLength` |  |
-| `placeholder` | `string` | `undefined` | Placeholder text for search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`placeholder` |  |
-| `type` | `string` | `undefined` | Type of input control e.g. 'text' or 'email' | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`type` |  |
-| `value` | `string` | `undefined` | Default value to be displayed/selected in the input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).`value` |  |
+| <a id="controltype-5"></a> `controlType` | `ControlType` | `ControlType.text` | Control type to be overridden in implementing class, used to render the proper input type e.g. 'text-input' | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`controlType`](public-api.md#controltype-3) | - |  |
+| <a id="formatvalue-5"></a> `formatValue` | (`value`: `string`) => `string` | `undefined` | Optional function to format the value before displaying it in the input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`formatValue`](public-api.md#formatvalue-3) |  |
+| <a id="formcontrol-5"></a> `formControl` | `FormControl`\<`string`\> | `undefined` | A reference to the form control it represents | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`formControl`](public-api.md#formcontrol-3) |  |
+| <a id="key-6"></a> `key` | `string` | `undefined` | Unique search-filter input key | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`key`](public-api.md#key-3) |  |
+| <a id="label-6"></a> `label` | `string` | `undefined` | Label text to be displayed for the search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`label`](public-api.md#label-3) |  |
+| <a id="maxlength-5"></a> `maxLength` | `number` | `undefined` | Max text length to be entered in the input component (default is 256) | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`maxLength`](public-api.md#maxlength-3) |  |
+| <a id="placeholder-5"></a> `placeholder` | `string` | `undefined` | Placeholder text for search-filter input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`placeholder`](public-api.md#placeholder-3) |  |
+| <a id="type-5"></a> `type` | `string` | `undefined` | Type of input control e.g. 'text' or 'email' | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`type`](public-api.md#type-3) |  |
+| <a id="value-5"></a> `value` | `string` | `undefined` | Default value to be displayed/selected in the input control | - | [`SearchFilterBase`](public-api.md#searchfilterbaset).[`value`](public-api.md#value-3) |  |
 
 ## Type Aliases
 
@@ -249,7 +271,7 @@ containing a collection of query URL parameters for easy integration.
 
 #### Index Signature
 
- \[`key`: `string`\]: `any`
+\[`key`: `string`\]: `any`
 
 ## Functions
 
@@ -261,7 +283,9 @@ Can be used to provide entry search filter configuration.
 
 #### Parameters
 
-• **config**: `Partial`\<[`EntrySearchFilterConfig`](public-api.md#entrysearchfilterconfig)\>
+##### config
+
+`Partial`\<[`EntrySearchFilterConfig`](public-api.md#entrysearchfilterconfig)\>
 
 #### Returns
 

--- a/apps/demo-app/src/assets/api/@enigmatry/entry-components/validation/public-api.md
+++ b/apps/demo-app/src/assets/api/@enigmatry/entry-components/validation/public-api.md
@@ -23,7 +23,7 @@ The messages are separated with coma(,) and displayed as _innerHTML_ value of ho
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| `control` | `AbstractControl`\<`any`, `any`\> | Form control for which the validation messages are displayed for. |  |
+| <a id="control"></a> `control` | `AbstractControl` | Form control for which the validation messages are displayed for. |  |
 
 #### Methods
 
@@ -78,7 +78,7 @@ The messages are displayed as a list, each message in a new row.
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| `form` | `UntypedFormGroup` | A form group for which the validation errors are being displayed. |  |
+| <a id="form"></a> `form` | `UntypedFormGroup` | A form group for which the validation errors are being displayed. |  |
 
 ***
 
@@ -90,7 +90,7 @@ Used to provide default configurations on module level.
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| `validationMessages` | [`IEntryValidationMessage`](public-api.md#ientryvalidationmessage)[] | Validation key to message configuration on module level. Used to configure client side validation messages for standard validators (_required_, _minLength_, _email_, etc.). **NOTE:** If using _Formly_ package to render forms, this configuration should not be used. Instead, use `FormlyModule` to configure validation messages. **Example** `new EntryValidationConfig() { validationMessages: [ { name: 'required': message: 'This field is mandatory' }, { name: 'minlength', message: (control: AbstractControl) => `Minimal length is ${control.errors.minlength.requiredLength}`} ] }` |  |
+| <a id="validationmessages"></a> `validationMessages` | [`IEntryValidationMessage`](public-api.md#ientryvalidationmessage)[] | Validation key to message configuration on module level. Used to configure client side validation messages for standard validators (_required_, _minLength_, _email_, etc.). **NOTE:** If using _Formly_ package to render forms, this configuration should not be used. Instead, use `FormlyModule` to configure validation messages. **Example** `new EntryValidationConfig() { validationMessages: [ { name: 'required': message: 'This field is mandatory' }, { name: 'minlength', message: (control: AbstractControl) => `Minimal length is ${control.errors.minlength.requiredLength}`} ] }` |  |
 
 ## Interfaces
 
@@ -102,8 +102,8 @@ Used to configure mapping between validation keys and messages
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| `message` | `string` \| (`control`) => `string` | Validation message. Can be static string or expression returning string (when messages need to be resolved dynamically: parametrization, localization, etc.). |  |
-| `name` | `string` | Validation key (e.g. '_required_', '_minlength_', '_email_', etc.) |  |
+| <a id="message"></a> `message` | `string` \| (`control`) => `string` | Validation message. Can be static string or expression returning string (when messages need to be resolved dynamically: parametrization, localization, etc.). |  |
+| <a id="name"></a> `name` | `string` | Validation key (e.g. '_required_', '_minlength_', '_email_', etc.) |  |
 
 ***
 
@@ -149,7 +149,9 @@ Can be used to provide entry validation configuration.
 
 #### Parameters
 
-• **config**: `Partial`\<[`EntryValidationConfig`](public-api.md#entryvalidationconfig)\>
+##### config
+
+`Partial`\<[`EntryValidationConfig`](public-api.md#entryvalidationconfig)\>
 
 #### Returns
 
@@ -166,11 +168,15 @@ The errors are applied to multiple levels: form, form group, form array, and for
 
 #### Parameters
 
-• **error**: [`IValidationProblemDetails`](public-api.md#ivalidationproblemdetails)
+##### error
+
+[`IValidationProblemDetails`](public-api.md#ivalidationproblemdetails)
 
 Server side validation errors response.
 
-• **form**: `UntypedFormGroup`
+##### form
+
+`UntypedFormGroup`
 
 Form to apply validation errors to.
 

--- a/libs/entry-components/search-filter/entry-search-filter.component.ts
+++ b/libs/entry-components/search-filter/entry-search-filter.component.ts
@@ -1,15 +1,16 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Inject, Input, OnInit, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, inject, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
-import { SearchFilterParams } from './search-filter-params.type';
-import { ENTRY_SEARCH_FILTER_CONFIG, EntrySearchFilterConfig } from './search-filter-config.model';
-import { SearchFilterBase } from './search-filter-base.model';
-import { TextSearchFilter } from './text/text-search-filter.model';
-import { SelectSearchFilter } from './select/select-search-filter.model';
+import { Subscription } from 'rxjs';
 import { AutocompleteSearchFilter } from './autocomplete/autocomplete-search-filter.model';
 import { ControlType } from './control-type';
-import { DateTimeSearchFilter } from './date-time/date-time-search-filter.model';
 import { DateSearchFilter } from './date/date-search-filter.model';
+import { DateTimeSearchFilter } from './date-time/date-time-search-filter.model';
+import { SearchFilterBase } from './search-filter-base.model';
+import { ENTRY_SEARCH_FILTER_CONFIG, EntrySearchFilterConfig } from './search-filter-config.model';
+import { SearchFilterParams } from './search-filter-params.type';
+import { SelectSearchFilter } from './select/select-search-filter.model';
 import { SelectOption } from './select-option.model';
+import { TextSearchFilter } from './text/text-search-filter.model';
 
 /**
  * Entry SearchFilter component.
@@ -20,8 +21,7 @@ import { SelectOption } from './select-option.model';
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: false
 })
-export class EntrySearchFilterComponent implements OnInit {
-
+export class EntrySearchFilterComponent implements OnInit, OnDestroy {
   /** Configuration of the search filters inputs that will be displayed in the search-filter component. */
   @Input() searchFilters: SearchFilterBase<any>[] = [];
   /**
@@ -31,11 +31,17 @@ export class EntrySearchFilterComponent implements OnInit {
 
   searchFilterForm!: UntypedFormGroup;
   controlType = ControlType;
-
-  constructor(@Inject(ENTRY_SEARCH_FILTER_CONFIG) public config: EntrySearchFilterConfig) { }
+  readonly config: EntrySearchFilterConfig = inject(ENTRY_SEARCH_FILTER_CONFIG);
+  private _valueChangeSubscription: Subscription | undefined;
 
   ngOnInit() {
     this.searchFilterForm = this.toFormGroup(this.searchFilters);
+  }
+
+  ngOnDestroy(): void {
+    if (this._valueChangeSubscription) {
+      this._valueChangeSubscription.unsubscribe();
+    }
   }
 
   onSubmit() {
@@ -43,33 +49,30 @@ export class EntrySearchFilterComponent implements OnInit {
     this.searchFilterChange.emit(formValue);
   }
 
-  toFormGroup(searchFilters: SearchFilterBase<any>[]) {
+  toFormGroup = (searchFilters: SearchFilterBase<any>[]) => {
     const group: any = {};
     searchFilters.forEach(searchFilter => {
       const formControl = searchFilter.toFormControl();
       group[searchFilter.key] = formControl;
       searchFilter.formControl = formControl;
+
+      if (searchFilter.formatValue) {
+        this._valueChangeSubscription = formControl.valueChanges.subscribe(value => {
+          const formatted = searchFilter.formatValue?.(value);
+          formControl.setValue(formatted, { emitEvent: false });
+        });
+      }
     });
     return new UntypedFormGroup(group);
-  }
+  };
 
-  asTextSearchFilter(searchFilter: SearchFilterBase<any>): TextSearchFilter {
-    return searchFilter as TextSearchFilter;
-  }
+  asTextSearchFilter = (searchFilter: SearchFilterBase<any>): TextSearchFilter => searchFilter as TextSearchFilter;
 
-  asSelectSearchFilter<T>(searchFilter: SearchFilterBase<T>): SelectSearchFilter<T> {
-    return searchFilter as SelectSearchFilter<T>;
-  }
+  asSelectSearchFilter = <T>(searchFilter: SearchFilterBase<T>): SelectSearchFilter<T> => searchFilter as SelectSearchFilter<T>;
 
-  asAutocompleteSearchFilter<T>(searchFilter: SearchFilterBase<SelectOption<T>>): AutocompleteSearchFilter<T> {
-    return searchFilter as AutocompleteSearchFilter<T>;
-  }
+  asAutocompleteSearchFilter = <T>(searchFilter: SearchFilterBase<SelectOption<T>>): AutocompleteSearchFilter<T> => searchFilter as AutocompleteSearchFilter<T>;
 
-  asDateTimeSearchFilter<T>(searchFilter: SearchFilterBase<T>): DateTimeSearchFilter<T> {
-    return searchFilter as DateTimeSearchFilter<T>;
-  }
+  asDateTimeSearchFilter = <T>(searchFilter: SearchFilterBase<T>): DateTimeSearchFilter<T> => searchFilter as DateTimeSearchFilter<T>;
 
-  asDateSearchFilter<T>(searchFilter: SearchFilterBase<T>): DateSearchFilter<T> {
-    return searchFilter as DateSearchFilter<T>;
-  }
+  asDateSearchFilter = <T>(searchFilter: SearchFilterBase<T>): DateSearchFilter<T> => searchFilter as DateSearchFilter<T>;
 }

--- a/libs/entry-components/search-filter/search-filter-base.model.ts
+++ b/libs/entry-components/search-filter/search-filter-base.model.ts
@@ -20,7 +20,11 @@ export class SearchFilterBase<T> {
   /** Max text length to be entered in the input component (default is 256) */
   maxLength: number;
   /** A reference to the form control it represents */
-  formControl: FormControl<T>;
+  formControl: FormControl<T | undefined>;
+  /** Optional function to format the value before displaying it in the input control */
+  formatValue: undefined | ((value: T) => T);
+
+  private readonly maxPossibleLength = 256;
 
   constructor(options: Partial<SearchFilterBase<T>> = {}) {
     this.value = options.value;
@@ -29,7 +33,8 @@ export class SearchFilterBase<T> {
     this.placeholder = options.placeholder || '';
     this.controlType = options.controlType || ControlType.text;
     this.type = options.type || ControlType.text;
-    this.maxLength = options.maxLength || 256;
+    this.maxLength = options.maxLength || this.maxPossibleLength;
+    this.formatValue = options.formatValue;
   }
 
   setValue(value: T | undefined) {

--- a/libs/entry-components/search-filter/search-filter-base.model.ts
+++ b/libs/entry-components/search-filter/search-filter-base.model.ts
@@ -22,7 +22,7 @@ export class SearchFilterBase<T> {
   /** A reference to the form control it represents */
   formControl: FormControl<T | undefined>;
   /** Optional function to format the value before displaying it in the input control */
-  formatValue: undefined | ((value: T) => T);
+  formatValue: ((value: T) => T) | undefined;
 
   private readonly maxPossibleLength = 256;
 


### PR DESCRIPTION
https://enigmatry.atlassian.net/browse/BP-1501

Add support for value formatting in Entry Search Filter components.

E.G., we need to mask text filter input to allow only decimal values that match current browser culture (if the culture is “en-EN”, user input “5,7” should be masked to “5.7“).