### PR TITLE
BP-1526: Turn off strict TS checks for nSwag

### DIFF
--- a/libs/entry-components/assets/nswag-templates/File.Header.liquid
+++ b/libs/entry-components/assets/nswag-templates/File.Header.liquid
@@ -1,0 +1,3 @@
+/* eslint-disable */
+// ReSharper disable InconsistentNaming
+// @ts-nocheck


### PR DESCRIPTION
Added liquid template responsible for controlling headers of nSwag-generated api-reference file.