### PR TITLE
fix sort by sort id

### DIFF
--- a/libs/entry-components/table/components/entry-table/entry-table.component.html
+++ b/libs/entry-components/table/components/entry-table/entry-table.component.html
@@ -2,7 +2,7 @@
 <table mat-table [class.mat-table-hover]="rowHover()" [class.mat-table-striped]="rowStriped()"
   [class.mat-table-with-data]="!hasNoResult()" [dataSource]="dataSource" matSort [matSortActive]="sortActive()!"
   [matSortDirection]="sortDirection()!" [matSortDisableClear]="sortDisableClear()" [matSortDisabled]="sortDisabled()"
-  [matSortStart]="sortStart()" (matSortChange)="sortChange.emit($event)">
+  [matSortStart]="sortStart()" (matSortChange)="handleSortChange($event)">
 
   <!-- Selection column -->
   @if(rowSelectable())

--- a/libs/entry-components/table/components/entry-table/entry-table.component.html
+++ b/libs/entry-components/table/components/entry-table/entry-table.component.html
@@ -1,6 +1,6 @@
 <!-- Table content -->
 <table mat-table [class.mat-table-hover]="rowHover()" [class.mat-table-striped]="rowStriped()"
-  [class.mat-table-with-data]="!hasNoResult()" [dataSource]="dataSource" matSort [matSortActive]="sortActive()!"
+  [class.mat-table-with-data]="!hasNoResult()" [dataSource]="dataSource" matSort [matSortActive]="resolvedSortActive()!"
   [matSortDirection]="sortDirection()!" [matSortDisableClear]="sortDisableClear()" [matSortDisabled]="sortDisabled()"
   [matSortStart]="sortStart()" (matSortChange)="handleSortChange($event)">
 

--- a/libs/entry-components/table/components/entry-table/entry-table.component.ts
+++ b/libs/entry-components/table/components/entry-table/entry-table.component.ts
@@ -75,6 +75,18 @@ export class EntryTableComponent<T> {
   readonly sortDisableClear = input<boolean>(false);
   readonly sortDisabled = input<boolean>(false);
   readonly sortStart = input<'asc' | 'desc'>('asc');
+  readonly resolvedSortActive = computed(() => {
+    if (!this.sortActive()) {
+      return this.sortActive();
+    }
+
+    const column = this.findColumnBySortKey(this.sortActive());
+    if (!column) {
+      return this.sortActive();
+    }
+
+    return column.sortProperties?.id ?? column.field;
+  });
   readonly sortChange = output<Sort>();
 
   // Row
@@ -197,10 +209,17 @@ export class EntryTableComponent<T> {
   };
 
   readonly handleSortChange = (sort: Sort): void => {
-    const column = this.columns().find(c => c.field === sort.active || c.sortProperties?.id === sort.active);
+    const column = this.findColumnBySortKey(sort.active);
     const active = column?.sortProperties?.id ?? sort.active;
     this.sortChange.emit({ ...sort, active });
   };
+
+  private readonly findColumnBySortKey = (sortKey?: string): ColumnDefinition | undefined =>
+    sortKey ?
+      this.columns().find(column =>
+        column.field.toLowerCase() === sortKey.toLowerCase()
+        || column.sortProperties?.id?.toLowerCase() === sortKey.toLowerCase())
+      : undefined;
 
   readonly scrollToTop = (): void => {
     this.elementRef.nativeElement.scrollTop = 0;

--- a/libs/entry-components/table/components/entry-table/entry-table.component.ts
+++ b/libs/entry-components/table/components/entry-table/entry-table.component.ts
@@ -196,6 +196,12 @@ export class EntryTableComponent<T> {
     this.pageChange.emit(event);
   };
 
+  readonly handleSortChange = (sort: Sort): void => {
+    const column = this.columns().find(c => c.field === sort.active || c.sortProperties?.id === sort.active);
+    const active = column?.sortProperties?.id ?? sort.active;
+    this.sortChange.emit({ ...sort, active });
+  };
+
   readonly scrollToTop = (): void => {
     this.elementRef.nativeElement.scrollTop = 0;
   };


### PR DESCRIPTION
EDIT: discarded as it was a mismatch between codegen version and entry building blocks version - more info: https://enigmatry.atlassian.net/browse/EBOPOR-17156

PR Summary

In entry-table.component.ts, we added resolvedSortActive and bound MatSort active state to a resolved/canonical sort key.
In entry-table.component.ts, we added handleSortChange so emitted sort events always use the configured server sort key (sortProperties.id) when present.
In entry-table.component.ts, we centralized matching logic into findColumnBySortKey (case-insensitive match against either field or sortProperties.id) so both URL binding and event emission use the same lookup.
In entry-table.component.html, MatSort now uses:
[matSortActive]="resolvedSortActive()"
(matSortChange)="handleSortChange($event)"

Why This Solves the Bug

Root bug: SortEvent was emitted with active based on column field (example: organizationName) instead of sortProperties.id (example: Organization.Name).
Fix: handleSortChange maps the active column to its configured sortProperties.id and emits that canonical value.
Result: Consumers (PagedQuery/router/API request) receive sortBy=Organization.Name when that override is configured, exactly matching expected behavior.
Why It Is Correct (Behavior Proof)

Click on a sortable column with sortProperties.id = Organization.Name.
MatSort emits an event for that column.
handleSortChange resolves column and emits { active: "Organization.Name", direction: ... }.
Existing query logic stores sortBy = active, so URL/query payload now carries Organization.Name (not organizationName).
On reload/manual URL navigation, resolvedSortActive maps incoming sort value back to the correct column sort header id, so header state and sorting behavior remain aligned.
Important Edge Case Covered

If sortProperties.id is missing, behavior falls back to field exactly as before.
If URL uses different casing (example: organization.name), lookup is case-insensitive for column resolution, reducing UI mismatch risk and keeping binding robust.