### PR TITLE
Make RowContextMenuFormatter generic

### DIFF
--- a/libs/entry-components/table/components/entry-cell-context-menu/entry-cell-context-menu.component.ts
+++ b/libs/entry-components/table/components/entry-cell-context-menu/entry-cell-context-menu.component.ts
@@ -20,6 +20,7 @@ export class EntryCellContextMenuComponent<T = unknown> {
   readonly isSubMenu = input<boolean>(false);
   readonly selected = output<string>();
   readonly menuItems = computed(() => (this.rowMenuFormatter()?.items
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     ? this.rowMenuFormatter()?.items(this.rowData()!)
     : this.items()) ?? []);
   readonly menu = viewChild<MatMenuPanel>('menu');

--- a/libs/entry-components/table/components/entry-cell-context-menu/entry-cell-context-menu.component.ts
+++ b/libs/entry-components/table/components/entry-cell-context-menu/entry-cell-context-menu.component.ts
@@ -12,15 +12,15 @@ import { RowContextMenuFormatter } from '../../interfaces/row-context-menu-forma
   templateUrl: './entry-cell-context-menu.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class EntryCellContextMenuComponent {
+export class EntryCellContextMenuComponent<T = unknown> {
   readonly items = input.required<ContextMenuItem[]>();
-  readonly rowMenuFormatter = input<RowContextMenuFormatter>();
-  readonly rowData = input<unknown>();
+  readonly rowMenuFormatter = input<RowContextMenuFormatter<T>>();
+  readonly rowData = input<T>();
   readonly triggerIcon = input<string>('more_vert');
   readonly isSubMenu = input<boolean>(false);
   readonly selected = output<string>();
   readonly menuItems = computed(() => (this.rowMenuFormatter()?.items
-    ? this.rowMenuFormatter()?.items(this.rowData)
+    ? this.rowMenuFormatter()?.items(this.rowData()!)
     : this.items()) ?? []);
   readonly menu = viewChild<MatMenuPanel>('menu');
   readonly subMenu = viewChild<EntryCellContextMenuComponent>('subMenu');

--- a/libs/entry-components/table/components/entry-table/entry-table.component.ts
+++ b/libs/entry-components/table/components/entry-table/entry-table.component.ts
@@ -100,7 +100,7 @@ export class EntryTableComponent<T> {
   readonly showContextMenu = input<boolean>(false);
   readonly contextMenuItems = input<ContextMenuItem[]>([]);
   readonly contextMenuTemplate = input<TemplateRef<unknown> | null>(null);
-  readonly rowContextMenuFormatter = input<RowContextMenuFormatter>();
+  readonly rowContextMenuFormatter = input<RowContextMenuFormatter<T>>();
   readonly contextMenuItemSelected = output<{ itemId: string; rowData: T }>();
 
   // No Result

--- a/libs/entry-components/table/interfaces/row-context-menu-formatter.ts
+++ b/libs/entry-components/table/interfaces/row-context-menu-formatter.ts
@@ -1,5 +1,5 @@
 import { ContextMenuItem } from './context-menu-item';
 
-export interface RowContextMenuFormatter {
-  items: (rowData: unknown) => ContextMenuItem[];
+export interface RowContextMenuFormatter<T = unknown> {
+  items: (rowData: T) => ContextMenuItem[];
 }


### PR DESCRIPTION
Previously, RowContextMenuFormatter defined its items callback with rowData: unknown, which forced every implementation to either cast the parameter or accept a loosely typed unknown argument instead of the actual row data type.
This PR makes the interface generic — RowContextMenuFormatter<T> — so implementations can declare the exact row type they expect.
EntryTableComponent is already generic (EntryTableComponent<T>), so rowContextMenuFormatter now uses RowContextMenuFormatter<T> to match. EntryCellContextMenuComponent was made generic accordingly.
A pre-existing bug was also fixed: rowData (the signal) was being passed into items(...) instead of rowData() (its value), which went undetected because unknown accepts anything.