### PR TITLE
Fix row selection not triggering change detection in entry table

### DIFF
--- a/libs/entry-components/table/components/entry-table/entry-table.component.ts
+++ b/libs/entry-components/table/components/entry-table/entry-table.component.ts
@@ -177,21 +177,23 @@ export class EntryTableComponent<T> {
   };
 
   readonly toggleSelectAllCheckbox = (): void => {
+    const current = this.rowSelection();
     if (this.allRowsSelected()) {
-      this.rowSelection().clear();
+        current.clear();
     } else {
-      this.dataSource.data.forEach(row => {
-        if (!this.rowSelectionFormatter().disabled?.(row)) {
-          this.rowSelection().select(row);
-        }
-      });
+        this.dataSource.data.forEach(row => {
+            if (!this.rowSelectionFormatter().disabled?.(row)) {
+                current.select(row);
+            }
+        });
     }
-    this.rowSelection.set(this.rowSelection());
+    this.rowSelection.set(new SelectionModel(current.isMultipleSelection(), [...current.selected]));
   };
 
   readonly toggleRowSelection = (row: T) => {
-    this.rowSelection().toggle(row);
-    this.rowSelection.set(this.rowSelection());
+    const current = this.rowSelection();
+    current.toggle(row);
+    this.rowSelection.set(new SelectionModel(current.isMultipleSelection(), [...current.selected]));
   };
 
   readonly handlePage = (event: PageEvent) => {


### PR DESCRIPTION
toggleRowSelection and toggleSelectAllCheckbox were mutating the existing SelectionModel instance in-place and then calling .set() with the same reference, which did not trigger Angular's signal change detection since the reference hadn't changed.

Fixed by creating a new SelectionModel instance with the updated selection on each toggle, ensuring the signal emits a new value and the UI updates correctly.