### PR TITLE
BP-1631- Date-time picker not updating input display on time-only change

### DIFF
--- a/libs/entry-components/date-time-picker/date-time-picker.component.ts
+++ b/libs/entry-components/date-time-picker/date-time-picker.component.ts
@@ -107,10 +107,12 @@ export class EntryDateTimePickerComponent<D> implements OnInit, OnDestroy {
       .pipe(takeUntil(this.$destroy))
       .subscribe(value => {
         this.timePicker.to24HourClock();
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.dateTimeAdapter.setTime(value!, this.timePicker.hours, this.timePicker.minutes, this.timePicker.seconds);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.formControl.setValue(value!);
+        const dateTime = value ? this.dateTimeAdapter.clone(value) : value;
+        if (dateTime) {
+          this.dateTimeAdapter.setTime(dateTime, this.timePicker.hours, this.timePicker.minutes, this.timePicker.seconds);
+        }
+
+        this.formControl.setValue(dateTime as D);
         this.formControl.markAsDirty();
         this.formControl.markAsTouched();
       });


### PR DESCRIPTION
The time adapter's setTime mutates the Date in place and returns the
same reference. Material's datepicker input only re-renders its display
when given a new reference (writeValue uses `value !== this.value`), so
applying a time-only change updated the form control but left the input
text stale. Clone the date before applying the time so the control
receives a fresh reference and the input reformats.