### PR TITLE
BP-1633: Fix 1st item in the list context menu doesn't open sub-menu on hover

### DIFF
--- a/libs/entry-components/table/components/entry-cell-context-menu/entry-cell-context-menu.component.html
+++ b/libs/entry-components/table/components/entry-cell-context-menu/entry-cell-context-menu.component.html
@@ -8,23 +8,35 @@
 <mat-menu #menu="matMenu" class="entry-table-menu" role="menu">
     @for(menuItem of menuItems(); track menuItem.id)
     {
-        <button mat-menu-item [disabled]="menuItem.disabled"
-            [matMenuTriggerFor]="menuItem.items?.length ? (subMenu()?.menu() ?? null) : null"
-            (click)="!menuItem.items?.length && selected.emit(menuItem.id)" class="context-menu-item">
+        @if(menuItem.items?.length)
+        {
+            <button mat-menu-item [disabled]="menuItem.disabled" [matMenuTriggerFor]="subMenuCmp.menu() ?? null"
+                class="context-menu-item">
 
-            @if(menuItem.icon)
-            {
-                <mat-icon class="icon">{{menuItem.icon}}</mat-icon>
-            }
+                @if(menuItem.icon)
+                {
+                    <mat-icon class="icon">{{menuItem.icon}}</mat-icon>
+                }
 
-            <span class="description">{{menuItem.name}}</span>
+                <span class="description">{{menuItem.name}}</span>
 
-            @if(menuItem.items?.length)
-            {
-                <entry-cell-context-menu #subMenu [items]="menuItem.items ?? []" [rowData]="rowData()" [isSubMenu]="true"
-                    (selected)="selected.emit($event)">
+                <entry-cell-context-menu #subMenuCmp [items]="menuItem.items!" [rowData]="rowData()"
+                    [isSubMenu]="true" (selected)="selected.emit($event)">
                 </entry-cell-context-menu>
-            }
-        </button>
+            </button>
+        }
+        @else
+        {
+            <button mat-menu-item [disabled]="menuItem.disabled" (click)="selected.emit(menuItem.id)"
+                class="context-menu-item">
+
+                @if(menuItem.icon)
+                {
+                    <mat-icon class="icon">{{menuItem.icon}}</mat-icon>
+                }
+
+                <span class="description">{{menuItem.name}}</span>
+            </button>
+        }
     }
 </mat-menu>

--- a/libs/entry-components/table/components/entry-cell-context-menu/entry-cell-context-menu.component.ts
+++ b/libs/entry-components/table/components/entry-cell-context-menu/entry-cell-context-menu.component.ts
@@ -24,5 +24,4 @@ export class EntryCellContextMenuComponent<T = unknown> {
     ? this.rowMenuFormatter()?.items(this.rowData()!)
     : this.items()) ?? []);
   readonly menu = viewChild<MatMenuPanel>('menu');
-  readonly subMenu = viewChild<EntryCellContextMenuComponent>('subMenu');
 }


### PR DESCRIPTION
_BP-1633: Fix 1st item in the list context menu doesn't open sub-menu on hover_
https://enigmatry.atlassian.net/browse/BP-1633

**Context**

After upgrading Angular v19→v21, the row context menu misbehaves: the first menu item that has a submenu doesn't open its submenu on hover, while later submenu items do. Additionally, all parent buttons bind to the same first-match viewChild('subMenu') instance, so submenus 2..N actually open the first submenu's content and emit the wrong itemId — a latent bug the v21 bump surfaced.

Root cause is in EntryCellContextMenuComponent: a single first-match viewChild('subMenu') combined with a #subMenu template ref declared inside a nested @if inside the button. Every parent button binds [matMenuTriggerFor]="subMenu()?.menu() ?? null" to the same first instance; for the first item that value is null at bind time, so it never opens.

This repo (@enigmatry/entry-components) is the library source, so we apply the upstream fix directly here.

**Fix**

Make the trigger button and its submenu component siblings within the same @if branch, using a local template ref (subMenuCmp) instead of the shared viewChild. Each row then uses its own submenu instance and the ref is resolved lazily on hover.