### PR TITLE
WSR-5653: Add opt-in option grouping to select and autocomplete components

### DIFF
--- a/apps/demo-app/src/app/examples/form/select/select-example.component.html
+++ b/apps/demo-app/src/app/examples/form/select/select-example.component.html
@@ -2,5 +2,11 @@
 <formly-form [fields]="single"></formly-form>
 <p>Multi select</p>
 <formly-form [fields]="multi"></formly-form>
+<p>Grouped single select</p>
+<formly-form [fields]="groupedSingle"></formly-form>
+<p>Grouped multi select</p>
+<formly-form [fields]="groupedMulti"></formly-form>
 <p>Autocomplete</p>
 <formly-form [fields]="autocomplete"></formly-form>
+<p>Grouped autocomplete</p>
+<formly-form [fields]="groupedAutocomplete"></formly-form>

--- a/apps/demo-app/src/app/examples/form/select/select-example.component.md
+++ b/apps/demo-app/src/app/examples/form/select/select-example.component.md
@@ -22,4 +22,38 @@ builder.MultiSelectFormControl(x => x.Type)
 builder.AutocompleteFormControl(x => x.Type)
     .WithOptions(options => options.WithFixedValues<ProductType>()
     .WithSortKey("displayName"));
+
+// Grouped single select - dynamic options
+builder.SelectFormControl(x => x.CategoryId)
+    .WithOptions(options => options.WithDynamicValues()
+    .WithValueKey("id")
+    .WithDisplayKey("categoryName")
+    .WithSortKey("categoryName")
+    .WithGroupKey("categoryGroup"));
+
+// Grouped multi-select - fixed/enum options
+public enum ProductTypeGrouped
+{
+    [SelectOptionGroup("Consumables")]
+    Food = 0,
+    [SelectOptionGroup("Consumables")]
+    Drink = 1,
+    [SelectOptionGroup("Goods")]
+    Book = 2,
+    [SelectOptionGroup("Goods")]
+    Car = 3,
+}
+
+builder.MultiSelectFormControl(x => x.Type)
+    .WithOptions(options => options.WithFixedValues<ProductTypeGrouped>()
+    .WithSortKey("displayName")
+    .WithGroupKey("group"));
+
+// Grouped autocomplete - dynamic options
+builder.AutocompleteFormControl(x => x.CategoryId)
+    .WithOptions(options => options.WithDynamicValues()
+    .WithValueKey("id")
+    .WithDisplayKey("categoryName")
+    .WithSortKey("categoryName")
+    .WithGroupKey("categoryGroup"));
 ```

--- a/apps/demo-app/src/app/examples/form/select/select-example.component.ts
+++ b/apps/demo-app/src/app/examples/form/select/select-example.component.ts
@@ -17,6 +17,13 @@ export class SelectExampleComponent {
     { value: 3, displayName: `Car` }
   ];
 
+  @Input() groupedTypeOptions = [
+    { value: 0, displayName: `Food`, category: `Consumables` },
+    { value: 1, displayName: `Drink`, category: `Consumables` },
+    { value: 2, displayName: `Book`, category: `Goods` },
+    { value: 3, displayName: `Car`, category: `Goods` }
+  ];
+
   single: FormlyFieldConfig[] = [
     {
       key: 'type',
@@ -50,6 +57,41 @@ export class SelectExampleComponent {
     }
   ];
 
+  groupedSingle: FormlyFieldConfig[] = [
+    {
+      key: 'type',
+      type: 'select',
+      className: `entry-type-field entry-select`,
+      templateOptions: {
+        label: `Grouped single`,
+        placeholder: `Grouped single`,
+        description: ``,
+        options: of(this.groupedTypeOptions).pipe(map(opts => sortOptions(opts, 'value', 'displayName', undefined, 'category'))),
+        valueProp: 'value',
+        labelProp: 'displayName',
+        groupProp: 'category'
+      }
+    }
+  ];
+
+  groupedMulti: FormlyFieldConfig[] = [
+    {
+      key: 'type',
+      type: 'select',
+      className: `entry-type-field entry-select`,
+      templateOptions: {
+        label: `Grouped multi`,
+        placeholder: `Grouped multi`,
+        description: ``,
+        options: of(this.groupedTypeOptions).pipe(map(opts => sortOptions(opts, 'value', 'displayName', undefined, 'category'))),
+        valueProp: 'value',
+        labelProp: 'displayName',
+        groupProp: 'category',
+        multiple: true
+      }
+    }
+  ];
+
   autocomplete: FormlyFieldConfig[] = [
     {
       key: 'type',
@@ -62,6 +104,23 @@ export class SelectExampleComponent {
         options: of(this.typeOptions).pipe(map(opts => sortOptions(opts, 'value', 'displayName'))),
         valueProp: 'value',
         labelProp: 'displayName'
+      }
+    }
+  ];
+
+  groupedAutocomplete: FormlyFieldConfig[] = [
+    {
+      key: 'type',
+      type: 'autocomplete',
+      className: `entry-type-field entry-autocomplete`,
+      templateOptions: {
+        label: `Grouped autocomplete`,
+        placeholder: `Grouped autocomplete`,
+        description: ``,
+        options: of(this.groupedTypeOptions).pipe(map(opts => sortOptions(opts, 'value', 'displayName', undefined, 'category'))),
+        valueProp: 'value',
+        labelProp: 'displayName',
+        groupProp: 'category'
       }
     }
   ];

--- a/apps/demo-app/src/app/examples/search-filter/search-filter/search-filter-example.component.ts
+++ b/apps/demo-app/src/app/examples/search-filter/search-filter/search-filter-example.component.ts
@@ -68,10 +68,7 @@ export class SearchFilterExampleComponent {
         multiSelect: true,
         options: Object.values(Occupation)
           .filter(value => typeof value === 'number')
-          .map((value: number) => new SelectOption(
-            value,
-            Occupation[value].replace(/^[a-z]/u, x => x.toUpperCase()),
-            this.occupationGroup(value)))
+          .map((value: number) => new SelectOption(value, Occupation[value].replace(/^[a-z]/u, x => x.toUpperCase())))
       }),
       new SelectSearchFilter({
         key: 'username',
@@ -107,16 +104,6 @@ export class SearchFilterExampleComponent {
     ];
   }
 
-  private readonly occupationGroups: Partial<Record<Occupation, string>> = {
-    [Occupation.electrician]: 'Skilled trades',
-    [Occupation.plumber]: 'Skilled trades',
-    [Occupation.doctor]: 'Professional',
-    [Occupation.teacher]: 'Professional',
-    [Occupation.painter]: 'Creative',
-    [Occupation.baker]: 'Creative',
-    [Occupation.soldier]: 'Public service'
-  };
-
   private readonly countryContinents: Partial<Record<Country, string>> = {
     [Country.unitedStates]: 'Americas',
     [Country.canada]: 'Americas',
@@ -131,8 +118,6 @@ export class SearchFilterExampleComponent {
     [Country.australia]: 'Oceania',
     [Country.southAfrica]: 'Africa'
   };
-
-  private occupationGroup = (occupation: Occupation): string => this.occupationGroups[occupation] ?? 'Other';
 
   private countryContinent = (country: Country): string => this.countryContinents[country] ?? 'Europe';
 

--- a/apps/demo-app/src/app/examples/search-filter/search-filter/search-filter-example.component.ts
+++ b/apps/demo-app/src/app/examples/search-filter/search-filter/search-filter-example.component.ts
@@ -68,7 +68,10 @@ export class SearchFilterExampleComponent {
         multiSelect: true,
         options: Object.values(Occupation)
           .filter(value => typeof value === 'number')
-          .map((value: number) => new SelectOption(value, Occupation[value].replace(/^[a-z]/u, x => x.toUpperCase())))
+          .map((value: number) => new SelectOption(
+            value,
+            Occupation[value].replace(/^[a-z]/u, x => x.toUpperCase()),
+            this.occupationGroup(value)))
       }),
       new SelectSearchFilter({
         key: 'username',
@@ -87,7 +90,7 @@ export class SearchFilterExampleComponent {
         search: (input: string | null) => of(Object.values(Country)
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           .filter(value => value.toLocaleLowerCase().includes(input!.toLocaleLowerCase()))
-          .map(country => new SelectOption(country, country)))
+          .map(country => new SelectOption(country, country, this.countryContinent(country))))
       }),
       new DateTimeSearchFilter({
         key: 'dateOfBirth',
@@ -103,6 +106,35 @@ export class SearchFilterExampleComponent {
       })
     ];
   }
+
+  private readonly occupationGroups: Partial<Record<Occupation, string>> = {
+    [Occupation.electrician]: 'Skilled trades',
+    [Occupation.plumber]: 'Skilled trades',
+    [Occupation.doctor]: 'Professional',
+    [Occupation.teacher]: 'Professional',
+    [Occupation.painter]: 'Creative',
+    [Occupation.baker]: 'Creative',
+    [Occupation.soldier]: 'Public service'
+  };
+
+  private readonly countryContinents: Partial<Record<Country, string>> = {
+    [Country.unitedStates]: 'Americas',
+    [Country.canada]: 'Americas',
+    [Country.mexico]: 'Americas',
+    [Country.brazil]: 'Americas',
+    [Country.argentina]: 'Americas',
+    [Country.china]: 'Asia',
+    [Country.india]: 'Asia',
+    [Country.japan]: 'Asia',
+    [Country.southKorea]: 'Asia',
+    [Country.indonesia]: 'Asia',
+    [Country.australia]: 'Oceania',
+    [Country.southAfrica]: 'Africa'
+  };
+
+  private occupationGroup = (occupation: Occupation): string => this.occupationGroups[occupation] ?? 'Other';
+
+  private countryContinent = (country: Country): string => this.countryContinents[country] ?? 'Europe';
 
   private maskDecimalScore(value: string): string {
     const exampleDecimalValue = 1.1;

--- a/apps/demo-app/src/assets/api/@enigmatry/entry-components/search-filter/public-api.md
+++ b/apps/demo-app/src/assets/api/@enigmatry/entry-components/search-filter/public-api.md
@@ -195,6 +195,7 @@ Model used to populate select or autocomplete options.
 
 | Property | Modifier | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ | ------ |
+| <a id="group"></a> `group?` | `public` | `string` | Optional group name. Options sharing the same group are rendered together under a group header. |  |
 | <a id="key-4"></a> `key` | `public` | `T` | Key used as a value for selected option |  |
 | <a id="label-4"></a> `label` | `public` | `string` | String value used as display label of select option |  |
 

--- a/libs/entry-components/search-filter/README.md
+++ b/libs/entry-components/search-filter/README.md
@@ -73,6 +73,25 @@ filters = [
 </entry-search-filter>
 ```
 
+## Grouping select/autocomplete options
+
+Both `SelectSearchFilter` and `AutocompleteSearchFilter` support grouping options under a header by passing an
+optional `group` name as the third `SelectOption` constructor argument. Options are rendered opt-in as-is (flat)
+when `group` is omitted; when set, options sharing the same group name are rendered together under a `mat-optgroup`
+header, in first-appearance order.
+
+```ts
+new SelectSearchFilter({
+  key: 'occupation',
+  label: 'Occupation',
+  options: [
+    new SelectOption(Occupation.electrician, 'Electrician', 'Skilled trades'),
+    new SelectOption(Occupation.plumber, 'Plumber', 'Skilled trades'),
+    new SelectOption(Occupation.doctor, 'Doctor', 'Professional')
+  ]
+})
+```
+
 ## Configuration
 
 - provide entry search filter config (optional):

--- a/libs/entry-components/search-filter/README.md
+++ b/libs/entry-components/search-filter/README.md
@@ -76,8 +76,8 @@ filters = [
 ## Grouping select/autocomplete options
 
 Both `SelectSearchFilter` and `AutocompleteSearchFilter` support grouping options under a header by passing an
-optional `group` name as the third `SelectOption` constructor argument. Options are rendered opt-in as-is (flat)
-when `group` is omitted; when set, options sharing the same group name are rendered together under a `mat-optgroup`
+optional `groupName` as the third `SelectOption` constructor argument. Options are rendered opt-in as-is (flat)
+when `groupName` is omitted; when set, options sharing the same group name are rendered together under a `mat-optgroup`
 header, in first-appearance order.
 
 ```ts

--- a/libs/entry-components/search-filter/autocomplete/autocomplete-search-filter.component.html
+++ b/libs/entry-components/search-filter/autocomplete/autocomplete-search-filter.component.html
@@ -3,23 +3,27 @@
     <input type="text" matInput [placeholder]="searchFilter.placeholder"
         [formControl]="searchField" [id]="searchFilter.key" [matAutocomplete]="auto">
     <mat-autocomplete [displayWith]="displayFn" #auto="matAutocomplete" (optionSelected)="onSelected($event)">
-        @for (group of (options$ | async | groupSelectOptions); track $index) {
-            @if (group.groupName) {
-                <mat-optgroup [label]="group.groupName">
-                    @for (child of group.options; track child.key) {
-                        <mat-option [value]="child">
-                            {{child.label}}
-                        </mat-option>
-                    }
-                </mat-optgroup>
-            } @else {
-                @for (child of group.options; track child.key) {
-                    <mat-option [value]="child">
-                        {{child.label}}
-                    </mat-option>
-                }
-            }
+        @for (group of (options$ | async | groupSelectOptions); track group.groupName) {
+            <ng-container *ngTemplateOutlet="groupTemplate; context: { $implicit: group }"></ng-container>
         }
     </mat-autocomplete>
     <mat-error entryDisplayControlValidation [control]="searchField"></mat-error>
 </mat-form-field>
+
+<ng-template #groupTemplate let-group>
+    @if (group.groupName) {
+        <mat-optgroup [label]="group.groupName">
+            <ng-container *ngTemplateOutlet="childOptionsTemplate; context: { $implicit: group.options }"></ng-container>
+        </mat-optgroup>
+    } @else {
+        <ng-container *ngTemplateOutlet="childOptionsTemplate; context: { $implicit: group.options }"></ng-container>
+    }
+</ng-template>
+
+<ng-template #childOptionsTemplate let-options>
+    @for (child of options; track child.key) {
+        <mat-option [value]="child">
+            {{child.label}}
+        </mat-option>
+    }
+</ng-template>

--- a/libs/entry-components/search-filter/autocomplete/autocomplete-search-filter.component.html
+++ b/libs/entry-components/search-filter/autocomplete/autocomplete-search-filter.component.html
@@ -3,10 +3,20 @@
     <input type="text" matInput [placeholder]="searchFilter.placeholder"
         [formControl]="searchField" [id]="searchFilter.key" [matAutocomplete]="auto">
     <mat-autocomplete [displayWith]="displayFn" #auto="matAutocomplete" (optionSelected)="onSelected($event)">
-        @for (option of options$ | async; track option.key) {
-            <mat-option [value]="option">
-                {{option.label}}
-            </mat-option>
+        @for (item of (options$ | async | groupSelectOptions); track $index) {
+            @if ('options' in item) {
+                <mat-optgroup [label]="item.label">
+                    @for (child of item.options; track child.key) {
+                        <mat-option [value]="child">
+                            {{child.label}}
+                        </mat-option>
+                    }
+                </mat-optgroup>
+            } @else {
+                <mat-option [value]="item">
+                    {{item.label}}
+                </mat-option>
+            }
         }
     </mat-autocomplete>
     <mat-error entryDisplayControlValidation [control]="searchField"></mat-error>

--- a/libs/entry-components/search-filter/autocomplete/autocomplete-search-filter.component.html
+++ b/libs/entry-components/search-filter/autocomplete/autocomplete-search-filter.component.html
@@ -4,26 +4,22 @@
         [formControl]="searchField" [id]="searchFilter.key" [matAutocomplete]="auto">
     <mat-autocomplete [displayWith]="displayFn" #auto="matAutocomplete" (optionSelected)="onSelected($event)">
         @for (group of (options$ | async | groupSelectOptions); track group.groupName) {
-            <ng-container *ngTemplateOutlet="groupTemplate; context: { $implicit: group }"></ng-container>
+            @if (group.groupName) {
+                <mat-optgroup [label]="group.groupName">
+                    @for (child of group.options; track child.key) {
+                        <mat-option [value]="child">
+                            {{child.label}}
+                        </mat-option>
+                    }
+                </mat-optgroup>
+            } @else {
+                @for (child of group.options; track child.key) {
+                    <mat-option [value]="child">
+                        {{child.label}}
+                    </mat-option>
+                }
+            }
         }
     </mat-autocomplete>
     <mat-error entryDisplayControlValidation [control]="searchField"></mat-error>
 </mat-form-field>
-
-<ng-template #groupTemplate let-group>
-    @if (group.groupName) {
-        <mat-optgroup [label]="group.groupName">
-            <ng-container *ngTemplateOutlet="childOptionsTemplate; context: { $implicit: group.options }"></ng-container>
-        </mat-optgroup>
-    } @else {
-        <ng-container *ngTemplateOutlet="childOptionsTemplate; context: { $implicit: group.options }"></ng-container>
-    }
-</ng-template>
-
-<ng-template #childOptionsTemplate let-options>
-    @for (child of options; track child.key) {
-        <mat-option [value]="child">
-            {{child.label}}
-        </mat-option>
-    }
-</ng-template>

--- a/libs/entry-components/search-filter/autocomplete/autocomplete-search-filter.component.html
+++ b/libs/entry-components/search-filter/autocomplete/autocomplete-search-filter.component.html
@@ -3,19 +3,21 @@
     <input type="text" matInput [placeholder]="searchFilter.placeholder"
         [formControl]="searchField" [id]="searchFilter.key" [matAutocomplete]="auto">
     <mat-autocomplete [displayWith]="displayFn" #auto="matAutocomplete" (optionSelected)="onSelected($event)">
-        @for (item of (options$ | async | groupSelectOptions); track $index) {
-            @if ('options' in item) {
-                <mat-optgroup [label]="item.label">
-                    @for (child of item.options; track child.key) {
+        @for (group of (options$ | async | groupSelectOptions); track $index) {
+            @if (group.groupName) {
+                <mat-optgroup [label]="group.groupName">
+                    @for (child of group.options; track child.key) {
                         <mat-option [value]="child">
                             {{child.label}}
                         </mat-option>
                     }
                 </mat-optgroup>
             } @else {
-                <mat-option [value]="item">
-                    {{item.label}}
-                </mat-option>
+                @for (child of group.options; track child.key) {
+                    <mat-option [value]="child">
+                        {{child.label}}
+                    </mat-option>
+                }
             }
         }
     </mat-autocomplete>

--- a/libs/entry-components/search-filter/entry-search-filter.module.ts
+++ b/libs/entry-components/search-filter/entry-search-filter.module.ts
@@ -13,6 +13,7 @@ import { AutocompleteSearchFilterComponent } from './autocomplete/autocomplete-s
 import { DateSearchFilterComponent } from './date/date-search-filter.component';
 import { DateTimeSearchFilterComponent } from './date-time/date-time-search-filter.component';
 import { EntrySearchFilterComponent } from './entry-search-filter.component';
+import { GroupSelectOptionsPipe } from './group-select-options.pipe';
 import { SelectSearchFilterComponent } from './select/select-search-filter.component';
 import { TextSearchFilterComponent } from './text/text-search-filter.component';
 
@@ -23,7 +24,8 @@ import { TextSearchFilterComponent } from './text/text-search-filter.component';
     SelectSearchFilterComponent,
     AutocompleteSearchFilterComponent,
     DateTimeSearchFilterComponent,
-    DateSearchFilterComponent
+    DateSearchFilterComponent,
+    GroupSelectOptionsPipe
   ],
   imports: [
     CommonModule,

--- a/libs/entry-components/search-filter/group-select-options.pipe.ts
+++ b/libs/entry-components/search-filter/group-select-options.pipe.ts
@@ -1,0 +1,38 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { SelectOption } from './select-option.model';
+
+export interface SelectOptionGroup {
+  label: string;
+  options: SelectOption<any>[];
+}
+
+// Groups a flat option list into buckets by each option's group name, preserving first-appearance order
+// of both groups and options within a group. Returns the input unchanged when no option sets a group.
+// Kept untyped (any) rather than a pipe-level generic: Angular's template type checker does not reliably
+// infer a transform<T> generic through a chained `| async | groupSelectOptions` expression.
+@Pipe({
+    name: 'groupSelectOptions',
+    standalone: false
+})
+export class GroupSelectOptionsPipe implements PipeTransform {
+  transform = (options: SelectOption<any>[] | null | undefined): Array<SelectOption<any> | SelectOptionGroup> => {
+    if (!options?.length || !options.some(option => option.group)) {
+      return options ?? [];
+    }
+
+    const groupOrder: string[] = [];
+    const groups = new Map<string, SelectOption<any>[]>();
+    options.forEach(option => {
+      const key = option.group ?? '';
+      const existing = groups.get(key);
+      if (existing) {
+        existing.push(option);
+      } else {
+        groupOrder.push(key);
+        groups.set(key, [option]);
+      }
+    });
+
+    return groupOrder.map(key => ({ label: key, options: groups.get(key) ?? [] }));
+  };
+}

--- a/libs/entry-components/search-filter/select-option-group.model.ts
+++ b/libs/entry-components/search-filter/select-option-group.model.ts
@@ -1,0 +1,7 @@
+import { SelectOption } from './select-option.model';
+
+/** A bucket of select/autocomplete options rendered together under an optional group header. */
+export interface SelectOptionGroup<T> {
+  groupName?: string;
+  options: SelectOption<T>[];
+}

--- a/libs/entry-components/search-filter/select-option.model.ts
+++ b/libs/entry-components/search-filter/select-option.model.ts
@@ -5,6 +5,6 @@ export class SelectOption<T> {
         public key: T,
         /** String value used as display label of select option */
         public label: string,
-        /** Optional group name. Options sharing the same group are rendered together under a group header. */
-        public group?: string) { }
+        /** Optional group name. Options sharing the same group name are rendered together under a group header. */
+        public groupName?: string) { }
 }

--- a/libs/entry-components/search-filter/select-option.model.ts
+++ b/libs/entry-components/search-filter/select-option.model.ts
@@ -4,5 +4,7 @@ export class SelectOption<T> {
         /** Key used as a value for selected option */
         public key: T,
         /** String value used as display label of select option */
-        public label: string) { }
+        public label: string,
+        /** Optional group name. Options sharing the same group are rendered together under a group header. */
+        public group?: string) { }
 }

--- a/libs/entry-components/search-filter/select/select-search-filter.component.html
+++ b/libs/entry-components/search-filter/select/select-search-filter.component.html
@@ -7,27 +7,31 @@
             </mat-option>
         }
         @if (searchFilter.options$ !== undefined) {
-            @for (item of (searchFilter.options$ | async | groupSelectOptions); track $index) {
-                @if ('options' in item) {
-                    <mat-optgroup [label]="item.label">
-                        @for (child of item.options; track child.key) {
+            @for (group of (searchFilter.options$ | async | groupSelectOptions); track $index) {
+                @if (group.groupName) {
+                    <mat-optgroup [label]="group.groupName">
+                        @for (child of group.options; track child.key) {
                             <mat-option [value]="child.key">{{child.label}}</mat-option>
                         }
                     </mat-optgroup>
                 } @else {
-                    <mat-option [value]="item.key">{{item.label}}</mat-option>
+                    @for (child of group.options; track child.key) {
+                        <mat-option [value]="child.key">{{child.label}}</mat-option>
+                    }
                 }
             }
         } @else {
-            @for (item of (searchFilter.options | groupSelectOptions); track $index) {
-                @if ('options' in item) {
-                    <mat-optgroup [label]="item.label">
-                        @for (child of item.options; track child.key) {
+            @for (group of (searchFilter.options | groupSelectOptions); track $index) {
+                @if (group.groupName) {
+                    <mat-optgroup [label]="group.groupName">
+                        @for (child of group.options; track child.key) {
                             <mat-option [value]="child.key">{{child.label}}</mat-option>
                         }
                     </mat-optgroup>
                 } @else {
-                    <mat-option [value]="item.key">{{item.label}}</mat-option>
+                    @for (child of group.options; track child.key) {
+                        <mat-option [value]="child.key">{{child.label}}</mat-option>
+                    }
                 }
             }
         }

--- a/libs/entry-components/search-filter/select/select-search-filter.component.html
+++ b/libs/entry-components/search-filter/select/select-search-filter.component.html
@@ -7,12 +7,28 @@
             </mat-option>
         }
         @if (searchFilter.options$ !== undefined) {
-            @for (option of searchFilter.options$ | async; track option.key) {
-                <mat-option [value]="option.key">{{option.label}}</mat-option>
+            @for (item of (searchFilter.options$ | async | groupSelectOptions); track $index) {
+                @if ('options' in item) {
+                    <mat-optgroup [label]="item.label">
+                        @for (child of item.options; track child.key) {
+                            <mat-option [value]="child.key">{{child.label}}</mat-option>
+                        }
+                    </mat-optgroup>
+                } @else {
+                    <mat-option [value]="item.key">{{item.label}}</mat-option>
+                }
             }
         } @else {
-            @for (option of searchFilter.options; track option.key) {
-                <mat-option [value]="option.key">{{option.label}}</mat-option>
+            @for (item of (searchFilter.options | groupSelectOptions); track $index) {
+                @if ('options' in item) {
+                    <mat-optgroup [label]="item.label">
+                        @for (child of item.options; track child.key) {
+                            <mat-option [value]="child.key">{{child.label}}</mat-option>
+                        }
+                    </mat-optgroup>
+                } @else {
+                    <mat-option [value]="item.key">{{item.label}}</mat-option>
+                }
             }
         }
     </mat-select>

--- a/libs/entry-components/search-filter/select/select-search-filter.component.html
+++ b/libs/entry-components/search-filter/select/select-search-filter.component.html
@@ -7,34 +7,30 @@
             </mat-option>
         }
         @if (searchFilter.options$ !== undefined) {
-            @for (group of (searchFilter.options$ | async | groupSelectOptions); track $index) {
-                @if (group.groupName) {
-                    <mat-optgroup [label]="group.groupName">
-                        @for (child of group.options; track child.key) {
-                            <mat-option [value]="child.key">{{child.label}}</mat-option>
-                        }
-                    </mat-optgroup>
-                } @else {
-                    @for (child of group.options; track child.key) {
-                        <mat-option [value]="child.key">{{child.label}}</mat-option>
-                    }
-                }
+            @for (group of (searchFilter.options$ | async | groupSelectOptions); track group.groupName) {
+                <ng-container *ngTemplateOutlet="groupTemplate; context: { $implicit: group }"></ng-container>
             }
         } @else {
-            @for (group of (searchFilter.options | groupSelectOptions); track $index) {
-                @if (group.groupName) {
-                    <mat-optgroup [label]="group.groupName">
-                        @for (child of group.options; track child.key) {
-                            <mat-option [value]="child.key">{{child.label}}</mat-option>
-                        }
-                    </mat-optgroup>
-                } @else {
-                    @for (child of group.options; track child.key) {
-                        <mat-option [value]="child.key">{{child.label}}</mat-option>
-                    }
-                }
+            @for (group of (searchFilter.options | groupSelectOptions); track group.groupName) {
+                <ng-container *ngTemplateOutlet="groupTemplate; context: { $implicit: group }"></ng-container>
             }
         }
     </mat-select>
     <mat-error entryDisplayControlValidation [control]="form.get(searchFilter.key)!"></mat-error>
 </mat-form-field>
+
+<ng-template #groupTemplate let-group>
+    @if (group.groupName) {
+        <mat-optgroup [label]="group.groupName">
+            <ng-container *ngTemplateOutlet="childOptionsTemplate; context: { $implicit: group.options }"></ng-container>
+        </mat-optgroup>
+    } @else {
+        <ng-container *ngTemplateOutlet="childOptionsTemplate; context: { $implicit: group.options }"></ng-container>
+    }
+</ng-template>
+
+<ng-template #childOptionsTemplate let-options>
+    @for (child of options; track child.key) {
+        <mat-option [value]="child.key">{{child.label}}</mat-option>
+    }
+</ng-template>

--- a/libs/entry-components/search-filter/select/select-search-filter.component.html
+++ b/libs/entry-components/search-filter/select/select-search-filter.component.html
@@ -6,31 +6,20 @@
                 {{config.noneSelectedOptionText}}
             </mat-option>
         }
-        @if (searchFilter.options$ !== undefined) {
-            @for (group of (searchFilter.options$ | async | groupSelectOptions); track group.groupName) {
-                <ng-container *ngTemplateOutlet="groupTemplate; context: { $implicit: group }"></ng-container>
-            }
-        } @else {
-            @for (group of (searchFilter.options | groupSelectOptions); track group.groupName) {
-                <ng-container *ngTemplateOutlet="groupTemplate; context: { $implicit: group }"></ng-container>
+        @let groups = (searchFilter.options$ !== undefined ? (searchFilter.options$ | async) : searchFilter.options) | groupSelectOptions;
+        @for (group of groups; track group.groupName) {
+            @if (group.groupName) {
+                <mat-optgroup [label]="group.groupName">
+                    @for (child of group.options; track child.key) {
+                        <mat-option [value]="child.key">{{child.label}}</mat-option>
+                    }
+                </mat-optgroup>
+            } @else {
+                @for (child of group.options; track child.key) {
+                    <mat-option [value]="child.key">{{child.label}}</mat-option>
+                }
             }
         }
     </mat-select>
     <mat-error entryDisplayControlValidation [control]="form.get(searchFilter.key)!"></mat-error>
 </mat-form-field>
-
-<ng-template #groupTemplate let-group>
-    @if (group.groupName) {
-        <mat-optgroup [label]="group.groupName">
-            <ng-container *ngTemplateOutlet="childOptionsTemplate; context: { $implicit: group.options }"></ng-container>
-        </mat-optgroup>
-    } @else {
-        <ng-container *ngTemplateOutlet="childOptionsTemplate; context: { $implicit: group.options }"></ng-container>
-    }
-</ng-template>
-
-<ng-template #childOptionsTemplate let-options>
-    @for (child of options; track child.key) {
-        <mat-option [value]="child.key">{{child.label}}</mat-option>
-    }
-</ng-template>

--- a/libs/entry-form/autocomplete/check-autocomplete-input.directive.ts
+++ b/libs/entry-form/autocomplete/check-autocomplete-input.directive.ts
@@ -3,7 +3,7 @@ import { AbstractControl, NgControl } from '@angular/forms';
 import { MatAutocompleteTrigger } from '@angular/material/autocomplete';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { SelectOption } from './select-configuration.interface';
+import { findOptionByLabel, findOptionByValue, SelectOption } from './select-configuration.interface';
 
 @Directive({
     selector: '[entryCheckAutocompleteInput]',
@@ -47,12 +47,11 @@ export class CheckAutocompleteInputDirective implements OnChanges, AfterViewInit
     if (!controlValue) {
       return;
     }
-    if (this.options.find(option => option.value === controlValue)) {
+    if (findOptionByValue(this.options, controlValue)) {
       return;
     }
 
-    const matchedOption = this.options
-      .find(option => option.label.toLowerCase() === controlValue.toLowerCase());
+    const matchedOption = findOptionByLabel(this.options, controlValue);
 
     if (matchedOption) {
       this.control.patchValue(matchedOption.value);
@@ -63,6 +62,6 @@ export class CheckAutocompleteInputDirective implements OnChanges, AfterViewInit
 
   private applySelectedValue = (value: any) => {
     const inputElement = this.elemRef.nativeElement as HTMLInputElement;
-    inputElement.value = this.options.find(option => option.value === value)?.label ?? '';
+    inputElement.value = findOptionByValue(this.options, value)?.label ?? '';
   };
 }

--- a/libs/entry-form/autocomplete/check-autocomplete-input.directive.ts
+++ b/libs/entry-form/autocomplete/check-autocomplete-input.directive.ts
@@ -3,7 +3,8 @@ import { AbstractControl, NgControl } from '@angular/forms';
 import { MatAutocompleteTrigger } from '@angular/material/autocomplete';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { findOptionByLabel, findOptionByValue, SelectOption } from './select-configuration.interface';
+import { findOptionByLabel, findOptionByValue } from './select-configuration.interface';
+import { SelectOption } from './select-option.model';
 
 @Directive({
     selector: '[entryCheckAutocompleteInput]',

--- a/libs/entry-form/autocomplete/display-with-autocomplete.pipe.ts
+++ b/libs/entry-form/autocomplete/display-with-autocomplete.pipe.ts
@@ -1,10 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { SelectOption } from './select-configuration.interface';
+import { findOptionByValue, SelectOption } from './select-configuration.interface';
 
 @Pipe({
     name: 'displayWithAutocomplete',
     standalone: false
 })
 export class DisplayWithAutocompletePipe implements PipeTransform {
-  transform = (options: SelectOption[]): (value: any) => string => (value: any) => options.find(o => o.value === value)?.label ?? '';
+  transform = (options: SelectOption[]): (value: any) => string => (value: any) => findOptionByValue(options, value)?.label ?? '';
 }

--- a/libs/entry-form/autocomplete/display-with-autocomplete.pipe.ts
+++ b/libs/entry-form/autocomplete/display-with-autocomplete.pipe.ts
@@ -1,5 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { findOptionByValue, SelectOption } from './select-configuration.interface';
+import { findOptionByValue } from './select-configuration.interface';
+import { SelectOption } from './select-option.model';
 
 @Pipe({
     name: 'displayWithAutocomplete',

--- a/libs/entry-form/autocomplete/filter-with-autocomplete.pipe.ts
+++ b/libs/entry-form/autocomplete/filter-with-autocomplete.pipe.ts
@@ -11,6 +11,10 @@ export class FilterWithAutocompletePipe implements PipeTransform {
       return options;
     }
     const labelStartsWith = filterWith.toLowerCase();
-    return options.filter(option => option.label.toLowerCase().includes(labelStartsWith));
+    return options
+      .map(option => option.group ?
+        { ...option, group: option.group.filter(child => child.label.toLowerCase().includes(labelStartsWith)) } :
+        option)
+      .filter(option => option.group ? option.group.length > 0 : option.label.toLowerCase().includes(labelStartsWith));
   };
 }

--- a/libs/entry-form/autocomplete/filter-with-autocomplete.pipe.ts
+++ b/libs/entry-form/autocomplete/filter-with-autocomplete.pipe.ts
@@ -1,5 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { SelectOption } from './select-configuration.interface';
+import { SelectOption } from './select-option.model';
 
 @Pipe({
     name: 'filterWithAutocomplete',
@@ -11,10 +11,6 @@ export class FilterWithAutocompletePipe implements PipeTransform {
       return options;
     }
     const labelStartsWith = filterWith.toLowerCase();
-    return options
-      .map(option => option.group ?
-        { ...option, group: option.group.filter(child => child.label.toLowerCase().includes(labelStartsWith)) } :
-        option)
-      .filter(option => option.group ? option.group.length > 0 : option.label.toLowerCase().includes(labelStartsWith));
+    return options.filter(option => option.label.toLowerCase().includes(labelStartsWith));
   };
 }

--- a/libs/entry-form/autocomplete/flatten-autocomplete-options.pipe.ts
+++ b/libs/entry-form/autocomplete/flatten-autocomplete-options.pipe.ts
@@ -11,8 +11,23 @@ import { SelectOption } from './select-option.model';
     standalone: false
 })
 export class FlattenAutocompleteOptionsPipe implements PipeTransform {
-  transform = (options: FormlySelectOption[] | null | undefined): SelectOption[] =>
-    (options ?? []).flatMap(option => option.group ?
-      option.group.map(child => ({ value: child.value, label: child.label, disabled: child.disabled, groupName: option.label })) :
-      [{ value: option.value, label: option.label, disabled: option.disabled }]);
+  transform = (options: FormlySelectOption[] | null | undefined): SelectOption[] => {
+    if (!options?.length) {
+      return [];
+    }
+
+    if (!options.some(option => option.group)) {
+      return options;
+    }
+
+    const result: SelectOption[] = [];
+    options.forEach(option => {
+      if (option.group) {
+        option.group.forEach(child => result.push({ value: child.value, label: child.label, disabled: child.disabled, groupName: option.label }));
+      } else {
+        result.push(option);
+      }
+    });
+    return result;
+  };
 }

--- a/libs/entry-form/autocomplete/flatten-autocomplete-options.pipe.ts
+++ b/libs/entry-form/autocomplete/flatten-autocomplete-options.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { FormlySelectOption } from '@ngx-formly/core/select';
+import { SelectOption } from './select-option.model';
+
+// Formly's own formlySelectOptions pipe nests grouped options one level deep, as
+// { label, group: FormlySelectOption[] } wrapper nodes (its fixed, external contract).
+// This flattens that into a flat SelectOption[], tagging each leaf with its wrapper's
+// label as groupName, so the rest of this module never has to deal with nesting.
+@Pipe({
+    name: 'flattenAutocompleteOptions',
+    standalone: false
+})
+export class FlattenAutocompleteOptionsPipe implements PipeTransform {
+  transform = (options: FormlySelectOption[] | null | undefined): SelectOption[] =>
+    (options ?? []).flatMap(option => option.group ?
+      option.group.map(child => ({ value: child.value, label: child.label, disabled: child.disabled, groupName: option.label })) :
+      [{ value: option.value, label: option.label, disabled: option.disabled }]);
+}

--- a/libs/entry-form/autocomplete/formly-autocomplete.component.html
+++ b/libs/entry-form/autocomplete/formly-autocomplete.component.html
@@ -1,4 +1,4 @@
-@let selectOptions = (props.options | formlySelectOptions: field | async) ?? [];
+@let selectOptions = ((props.options | formlySelectOptions: field | async) ?? []) | flattenAutocompleteOptions;
 
 <mat-form-field class="entry-autocomplete"
   [hideRequiredMarker]="true"
@@ -30,19 +30,21 @@
   <mat-autocomplete #auto="matAutocomplete"
     [autoActiveFirstOption]="true"
     [displayWith]="selectOptions | displayWithAutocomplete">
-    @for (item of selectOptions | filterWithAutocomplete: input.value; track $index) {
-      @if (item.group) {
-        <mat-optgroup [label]="item.label">
-          @for (child of item.group; track child.value) {
+    @for (group of selectOptions | filterWithAutocomplete: input.value | groupWithAutocomplete; track $index) {
+      @if (group.groupName) {
+        <mat-optgroup [label]="group.groupName">
+          @for (child of group.options; track child.value) {
             <mat-option [value]="child.value">
               {{ child.label }}
             </mat-option>
           }
         </mat-optgroup>
       } @else {
-        <mat-option [value]="item.value">
-          {{ item.label }}
-        </mat-option>
+        @for (child of group.options; track child.value) {
+          <mat-option [value]="child.value">
+            {{ child.label }}
+          </mat-option>
+        }
       }
     }
   </mat-autocomplete>

--- a/libs/entry-form/autocomplete/formly-autocomplete.component.html
+++ b/libs/entry-form/autocomplete/formly-autocomplete.component.html
@@ -30,10 +30,20 @@
   <mat-autocomplete #auto="matAutocomplete"
     [autoActiveFirstOption]="true"
     [displayWith]="selectOptions | displayWithAutocomplete">
-    @for (option of selectOptions | filterWithAutocomplete: input.value; track option.value) {
-      <mat-option [value]="option.value">
-        {{ option.label }}
-      </mat-option>
+    @for (item of selectOptions | filterWithAutocomplete: input.value; track $index) {
+      @if (item.group) {
+        <mat-optgroup [label]="item.label">
+          @for (child of item.group; track child.value) {
+            <mat-option [value]="child.value">
+              {{ child.label }}
+            </mat-option>
+          }
+        </mat-optgroup>
+      } @else {
+        <mat-option [value]="item.value">
+          {{ item.label }}
+        </mat-option>
+      }
     }
   </mat-autocomplete>
 

--- a/libs/entry-form/autocomplete/formly-autocomplete.component.html
+++ b/libs/entry-form/autocomplete/formly-autocomplete.component.html
@@ -31,7 +31,21 @@
     [autoActiveFirstOption]="true"
     [displayWith]="selectOptions | displayWithAutocomplete">
     @for (group of selectOptions | filterWithAutocomplete: input.value | groupWithAutocomplete; track group.groupName) {
-      <ng-container *ngTemplateOutlet="groupTemplate; context: { $implicit: group }"></ng-container>
+      @if (group.groupName) {
+        <mat-optgroup [label]="group.groupName">
+          @for (child of group.options; track child.value) {
+            <mat-option [value]="child.value">
+              {{ child.label }}
+            </mat-option>
+          }
+        </mat-optgroup>
+      } @else {
+        @for (child of group.options; track child.value) {
+          <mat-option [value]="child.value">
+            {{ child.label }}
+          </mat-option>
+        }
+      }
     }
   </mat-autocomplete>
 
@@ -43,22 +57,4 @@
     <mat-hint>{{ hint }}</mat-hint>
   }
 </mat-form-field>
-
-<ng-template #groupTemplate let-group>
-  @if (group.groupName) {
-    <mat-optgroup [label]="group.groupName">
-      <ng-container *ngTemplateOutlet="childOptionsTemplate; context: { $implicit: group.options }"></ng-container>
-    </mat-optgroup>
-  } @else {
-    <ng-container *ngTemplateOutlet="childOptionsTemplate; context: { $implicit: group.options }"></ng-container>
-  }
-</ng-template>
-
-<ng-template #childOptionsTemplate let-options>
-  @for (child of options; track child.value) {
-    <mat-option [value]="child.value">
-      {{ child.label }}
-    </mat-option>
-  }
-</ng-template>
 

--- a/libs/entry-form/autocomplete/formly-autocomplete.component.html
+++ b/libs/entry-form/autocomplete/formly-autocomplete.component.html
@@ -30,22 +30,8 @@
   <mat-autocomplete #auto="matAutocomplete"
     [autoActiveFirstOption]="true"
     [displayWith]="selectOptions | displayWithAutocomplete">
-    @for (group of selectOptions | filterWithAutocomplete: input.value | groupWithAutocomplete; track $index) {
-      @if (group.groupName) {
-        <mat-optgroup [label]="group.groupName">
-          @for (child of group.options; track child.value) {
-            <mat-option [value]="child.value">
-              {{ child.label }}
-            </mat-option>
-          }
-        </mat-optgroup>
-      } @else {
-        @for (child of group.options; track child.value) {
-          <mat-option [value]="child.value">
-            {{ child.label }}
-          </mat-option>
-        }
-      }
+    @for (group of selectOptions | filterWithAutocomplete: input.value | groupWithAutocomplete; track group.groupName) {
+      <ng-container *ngTemplateOutlet="groupTemplate; context: { $implicit: group }"></ng-container>
     }
   </mat-autocomplete>
 
@@ -57,4 +43,22 @@
     <mat-hint>{{ hint }}</mat-hint>
   }
 </mat-form-field>
+
+<ng-template #groupTemplate let-group>
+  @if (group.groupName) {
+    <mat-optgroup [label]="group.groupName">
+      <ng-container *ngTemplateOutlet="childOptionsTemplate; context: { $implicit: group.options }"></ng-container>
+    </mat-optgroup>
+  } @else {
+    <ng-container *ngTemplateOutlet="childOptionsTemplate; context: { $implicit: group.options }"></ng-container>
+  }
+</ng-template>
+
+<ng-template #childOptionsTemplate let-options>
+  @for (child of options; track child.value) {
+    <mat-option [value]="child.value">
+      {{ child.label }}
+    </mat-option>
+  }
+</ng-template>
 

--- a/libs/entry-form/autocomplete/formly-autocomplete.module.ts
+++ b/libs/entry-form/autocomplete/formly-autocomplete.module.ts
@@ -8,13 +8,17 @@ import { FormlySelectModule } from '@ngx-formly/core/select';
 import { CheckAutocompleteInputDirective } from './check-autocomplete-input.directive';
 import { DisplayWithAutocompletePipe } from './display-with-autocomplete.pipe';
 import { FilterWithAutocompletePipe } from './filter-with-autocomplete.pipe';
+import { FlattenAutocompleteOptionsPipe } from './flatten-autocomplete-options.pipe';
 import { FormlyAutocompleteComponent } from './formly-autocomplete.component';
+import { GroupWithAutocompletePipe } from './group-with-autocomplete.pipe';
 
 @NgModule({
   declarations: [
     FormlyAutocompleteComponent,
     DisplayWithAutocompletePipe,
     FilterWithAutocompletePipe,
+    FlattenAutocompleteOptionsPipe,
+    GroupWithAutocompletePipe,
     CheckAutocompleteInputDirective
   ],
   imports: [

--- a/libs/entry-form/autocomplete/group-with-autocomplete.pipe.ts
+++ b/libs/entry-form/autocomplete/group-with-autocomplete.pipe.ts
@@ -5,14 +5,12 @@ import { SelectOption } from './select-option.model';
 // Groups a flat option list into buckets by each option's group name, preserving first-appearance order
 // of both groups and options within a group. Ungrouped options are returned as a single group with no
 // groupName, so templates can always iterate groups without discriminating between shapes.
-// Kept untyped (any) rather than a pipe-level generic: Angular's template type checker does not reliably
-// infer a transform<T> generic through a chained `| async | groupSelectOptions` expression.
 @Pipe({
-    name: 'groupSelectOptions',
+    name: 'groupWithAutocomplete',
     standalone: false
 })
-export class GroupSelectOptionsPipe implements PipeTransform {
-  transform = (options: SelectOption<any>[] | null | undefined): Array<SelectOptionGroup<any>> => {
+export class GroupWithAutocompletePipe implements PipeTransform {
+  transform = (options: SelectOption[] | null | undefined): SelectOptionGroup[] => {
     if (!options?.length) {
       return [];
     }
@@ -22,7 +20,7 @@ export class GroupSelectOptionsPipe implements PipeTransform {
     }
 
     const groupOrder: string[] = [];
-    const groups = new Map<string, SelectOption<any>[]>();
+    const groups = new Map<string, SelectOption[]>();
     options.forEach(option => {
       const key = option.groupName ?? '';
       const existing = groups.get(key);

--- a/libs/entry-form/autocomplete/public-api.ts
+++ b/libs/entry-form/autocomplete/public-api.ts
@@ -1,3 +1,4 @@
 
 export { FormlyAutocompleteModule } from './formly-autocomplete.module';
 export * from './select-configuration.interface';
+export type { SelectOption } from './select-option.model';

--- a/libs/entry-form/autocomplete/select-configuration.interface.ts
+++ b/libs/entry-form/autocomplete/select-configuration.interface.ts
@@ -2,11 +2,38 @@ export interface SelectOption {
   value?: any;
   label: string;
   disabled?: boolean;
+  group?: SelectOption[];
 }
+
+// Recursively looks up an option by value, descending into `group` children for grouped option lists.
+export const findOptionByValue = (options: SelectOption[], value: any): SelectOption | undefined => {
+  for (const option of options) {
+    const found = option.group ? findOptionByValue(option.group, value) : option.value === value ? option : undefined;
+    if (found) {
+      return found;
+    }
+  }
+  return undefined;
+};
+
+// Recursively looks up an option by label (case-insensitive), descending into `group` children.
+export const findOptionByLabel = (options: SelectOption[], label: string): SelectOption | undefined => {
+  const lowerLabel = label.toLowerCase();
+  for (const option of options) {
+    const found = option.group ?
+      findOptionByLabel(option.group, label) :
+      option.label.toLowerCase() === lowerLabel ? option : undefined;
+    if (found) {
+      return found;
+    }
+  }
+  return undefined;
+};
 
 export interface SelectConfiguration {
   valueProperty?: string;
   labelProperty?: string;
+  groupProperty?: string;
   emptyOption?: SelectOption;
   sortProperty?: string;
   disable?: (option: SelectOption) => boolean;
@@ -18,11 +45,34 @@ const sortOptionsBy = (options: SelectOption[] | any[], sortProperty?: string, l
       (a[sortProperty]?.toString() ?? '').localeCompare(b[sortProperty]?.toString() ?? '', locale || 'en-US', { sensitivity: 'base' })) :
         options;
 
+// Groups options by their first appearance in `options` (matching Formly's own grouping order),
+// then sorts each group's contents by sortProperty. Group order therefore follows the source data,
+// not the group label.
+const groupAndSortOptions =
+  (options: SelectOption[] | any[], groupProperty: string, sortProperty?: string, locale?: string): SelectOption[] | any[] => {
+    const groupOrder: string[] = [];
+    const groups = new Map<string, SelectOption[] | any[]>();
+    options.forEach(option => {
+      const key = (option[groupProperty] ?? '').toString();
+      const group = groups.get(key);
+      if (group) {
+        group.push(option);
+      } else {
+        groupOrder.push(key);
+        groups.set(key, [option]);
+      }
+    });
+    return groupOrder.flatMap(key => sortOptionsBy(groups.get(key) ?? [], sortProperty, locale));
+  };
+
 export const sortOptions =
-  (options: SelectOption[] | any[], valueProperty?: string, sortProperty?: string, locale?: string): SelectOption[] | any[] => {
+  (options: SelectOption[] | any[], valueProperty?: string, sortProperty?: string, locale?: string,
+   groupProperty?: string): SelectOption[] | any[] => {
     const optionsCopy = [...options];
-    return valueProperty ?
-      sortOptionsBy(optionsCopy.filter(opt => opt[valueProperty] === null), sortProperty, locale)
-        .concat(sortOptionsBy(optionsCopy.filter(opt => opt[valueProperty] !== null), sortProperty, locale)) :
-      sortOptionsBy(optionsCopy, sortProperty, locale);
+    const emptyOptions = valueProperty ? optionsCopy.filter(opt => opt[valueProperty] === null) : [];
+    const restOptions = valueProperty ? optionsCopy.filter(opt => opt[valueProperty] !== null) : optionsCopy;
+    return sortOptionsBy(emptyOptions, sortProperty, locale)
+      .concat(groupProperty ?
+        groupAndSortOptions(restOptions, groupProperty, sortProperty, locale) :
+        sortOptionsBy(restOptions, sortProperty, locale));
   };

--- a/libs/entry-form/autocomplete/select-configuration.interface.ts
+++ b/libs/entry-form/autocomplete/select-configuration.interface.ts
@@ -1,33 +1,11 @@
-export interface SelectOption {
-  value?: any;
-  label: string;
-  disabled?: boolean;
-  group?: SelectOption[];
-}
+import { SelectOption } from './select-option.model';
 
-// Recursively looks up an option by value, descending into `group` children for grouped option lists.
-export const findOptionByValue = (options: SelectOption[], value: any): SelectOption | undefined => {
-  for (const option of options) {
-    const found = option.group ? findOptionByValue(option.group, value) : option.value === value ? option : undefined;
-    if (found) {
-      return found;
-    }
-  }
-  return undefined;
-};
+export const findOptionByValue = (options: SelectOption[], value: any): SelectOption | undefined =>
+  options.find(option => option.value === value);
 
-// Recursively looks up an option by label (case-insensitive), descending into `group` children.
 export const findOptionByLabel = (options: SelectOption[], label: string): SelectOption | undefined => {
   const lowerLabel = label.toLowerCase();
-  for (const option of options) {
-    const found = option.group ?
-      findOptionByLabel(option.group, label) :
-      option.label.toLowerCase() === lowerLabel ? option : undefined;
-    if (found) {
-      return found;
-    }
-  }
-  return undefined;
+  return options.find(option => option.label.toLowerCase() === lowerLabel);
 };
 
 export interface SelectConfiguration {

--- a/libs/entry-form/autocomplete/select-option-group.model.ts
+++ b/libs/entry-form/autocomplete/select-option-group.model.ts
@@ -1,0 +1,7 @@
+import { SelectOption } from './select-option.model';
+
+/** A bucket of autocomplete options rendered together under an optional group header. */
+export interface SelectOptionGroup {
+  groupName?: string;
+  options: SelectOption[];
+}

--- a/libs/entry-form/autocomplete/select-option.model.ts
+++ b/libs/entry-form/autocomplete/select-option.model.ts
@@ -1,0 +1,6 @@
+export interface SelectOption {
+  value?: any;
+  label: string;
+  disabled?: boolean;
+  groupName?: string;
+}


### PR DESCRIPTION
https://enigmatry.atlassian.net/browse/WSR-5653

Adds opt-in mat-optgroup support so select/autocomplete options can be rendered under group headers, without changing behavior for existing ungrouped consumers.

entry-form:
- SelectConfiguration/sortOptions gain an optional groupProperty, used to pre-sort and bucket options by group before Formly's own select/autocomplete rendering groups them.
- The custom autocomplete field type (select's stock Formly type already supported groups) now renders mat-optgroup, with the search filter and value/label lookups updated to recurse into grouped options.
- Demo: grouped single/multi select and autocomplete examples added, plus corresponding C# builder-API doc snippets.

entry-components/search-filter:
- SelectOption gains an optional group name; a new GroupSelectOptionsPipe buckets flat option lists into groups (pass-through when unused).
- select-search-filter and autocomplete-search-filter now render mat-optgroup when options are grouped.
- Demo: existing occupation (select) and country (autocomplete) filters updated to show grouping on real data.
- README updated with a grouping usage example.

Verified via ng build (full template type-checking), eslint, and Playwright-driven browser testing of every grouped/ungrouped select/autocomplete combination in both libraries - zero console errors, ungrouped paths confirmed byte-identical to prior behavior.