### PR TITLE
Fix unresolved merge conflict markers in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2294,7 +2294,6 @@
         "postcss-selector-parser": "^7.1.1"
       }
     },
-<<<<<<< HEAD
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -2320,8 +2319,6 @@
         "tslib": "^2.4.0"
       }
     },
-=======
->>>>>>> master
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",


### PR DESCRIPTION
Commit 0bf7668 landed package-lock.json with unresolved conflict markers, leaving the file invalid JSON. npm does not fail on it because Arborist loads lockfiles through parse-conflict-json, which silently resolves the markers in memory - so `npm ci` and CI both stayed green while any tool using a standard JSON parser (SCA scanners, Dependabot, jq) would choke.

Removes the three marker lines only, keeping the HEAD side. Both @emnapi/core and @emnapi/runtime are present in the installed tree and are required by @emnapi/wasi-threads, which survived the merge already. No dependency versions or peer flags change.